### PR TITLE
Fix CLI dockerfile

### DIFF
--- a/parse/cmd/Dockerfile
+++ b/parse/cmd/Dockerfile
@@ -5,4 +5,4 @@ RUN apk add --no-cache git
 RUN apk add --no-cache the_silver_searcher
 RUN apk add --no-cache openssh
 
-COPY out/git-flag-parser /usr/local/bin/git-flag-parser
+COPY git-flag-parser /usr/local/bin/git-flag-parser


### PR DESCRIPTION
Tested this by releasing 0.1.0: https://cloud.docker.com/repository/docker/ldactions/git-flag-parser/tags

There was a bug in the dockerfile that led the `make` command to fail. We currently don't write binaries to `out`.