### PR TITLE
remove dependency on openssh

### DIFF
--- a/build/package/bitbucket-pipelines/Dockerfile
+++ b/build/package/bitbucket-pipelines/Dockerfile
@@ -3,7 +3,6 @@ FROM alpine:3.8
 RUN apk update
 RUN apk add --no-cache git
 RUN apk add --no-cache the_silver_searcher
-RUN apk add --no-cache openssh
 
 COPY ld-find-code-refs-bitbucket-pipeline /ld-find-code-refs-bitbucket-pipeline
 

--- a/build/package/cmd/Dockerfile
+++ b/build/package/cmd/Dockerfile
@@ -3,6 +3,5 @@ FROM alpine:3.8
 RUN apk update
 RUN apk add --no-cache git
 RUN apk add --no-cache the_silver_searcher
-RUN apk add --no-cache openssh
 
 COPY ld-find-code-refs /usr/local/bin/ld-find-code-refs

--- a/build/package/github-actions/Dockerfile
+++ b/build/package/github-actions/Dockerfile
@@ -3,7 +3,6 @@ FROM alpine:3.8
 RUN apk update
 RUN apk add --no-cache git
 RUN apk add --no-cache the_silver_searcher
-RUN apk add --no-cache openssh
 
 COPY ld-find-code-refs-github-action /ld-find-code-refs-github-action
 


### PR DESCRIPTION
Now that we removed the `cloneEndpoint` parameter, we no longer need the dependency on openssh. So, let's remove it.