### PR TITLE
Infer current branch checkout, remove repoHead arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ We provide turnkey support for common trigger mechanisms and CI / CD providers. 
 
 ## Execution via CLI
 
-The command line program may be run manually, and executed in an environment of your choosing.
+The command line program may be run manually, and executed in an environment of your choosing. The program requires your `git` repo to be cloned locally, and the currently checked out branch will be scanned for code references.
 
 ### Installing
 
@@ -95,7 +95,7 @@ A number of command-line arguments are available to the code ref finder, some op
 | Option | Description |
 |-|-|
 | `accessToken` | LaunchDarkly [personal access token](https://docs.launchdarkly.com/docs/api-access-tokens) with writer-level access, or access to the `code-reference-repository` [custom role](https://docs.launchdarkly.com/v2.0/docs/custom-roles) resource |
-| `dir` | **Absolute** path to existing checkout of the git repo. Relative paths are not currently supported. |
+| `dir` | **Absolute** path to existing checkout of the git repo. Relative paths are not currently supported. The currently checked out branch will be scanned for code references. |
 | `projKey` | A LaunchDarkly project key. |
 | `repoName` | Git repo name. Will be displayed in LaunchDarkly. Repo names must only contain letters, numbers, '.', '_' or '-'." |
 
@@ -110,7 +110,6 @@ Although these arguments are optional, a (*) indicates a recommended parameter t
 | `defaultBranch` | The git default branch. The LaunchDarkly UI will default to display code references for this branch. | "master" |
 | `exclude` (*) | A regular expression (PCRE) defining the files and directories which the flag finder should exclude. Partial matches are allowed. Examples: `vendor/`, `\.css`, `vendor/|\.css` | "" |
 | `updateSequenceId` | An integer representing the order number of code reference updates. Used to version updates across concurrent executions of the program. If not provided, data will always be updated. If provided, data will only be updated if the existing `updateSequenceId` is less than the new `updateSequenceId`. Examples: the time a `git push` was initiated, CI build number, the current unix timestamp. | n/a |
-| `repoHead` (*) | The branch to scan for code references. Should be provided if the `git push` was initiated on a non-master branch. | "master" | no |
 | `repoType` (*) | The repo service provider. Used to generate repository links in the LaunchDarkly UI. Acceptable values: github\|bitbucket\|custom | "custom" |
 | `repoUrl` (*) | The display url for the repository. If provided for a github or bitbucket repository, LaunchDarkly will attempt to automatically generate source code links. Example: `https://github.com/launchdarkly/ld-find-code-refs` | "" |
 | `commitUrlTemplate` | If provided, LaunchDarkly will attempt to generate links to your Git service provider per commit. Example: `https://github.com/launchdarkly/ld-find-code-refs/commit/${sha}`. Allowed template variables: `branchName`, `sha`. If `commitUrlTemplate` is not provided, but `repoUrl` is provided and `repoType` is not custom, LaunchDarkly will automatically generate links to the repository for each commit. | "" |

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You can now run `ld-find-code-refs`.
 
 Precompiled binaries for the latest release can be found [here](https://github.com/launchdarkly/ld-find-code-refs/releases/latest).
 
-The `ld-find-code-refs` program requires [The Silver Searcher](https://github.com/ggreer/the_silver_searcher#installing) to be installed as a dependency, so make sure it has been installed and added to your system path before running the ld-find-code-refs.
+The `ld-find-code-refs` program requires [Git](https://git-scm.org) and [The Silver Searcher](https://github.com/ggreer/the_silver_searcher#installing) to be installed as a dependency, so make sure these dependencies have been installed and added to your system path before running `ld-find-code-refs`.
 
 ### Examples
 

--- a/build/package/bitbucket-pipelines/bitbucket-pipelines.go
+++ b/build/package/bitbucket-pipelines/bitbucket-pipelines.go
@@ -15,7 +15,6 @@ func main() {
 	options := map[string]string{
 		"repoType":         "bitbucket",
 		"repoName":         os.Getenv("BITBUCKET_REPO_SLUG"),
-		"repoHead":         os.Getenv("BITBUCKET_BRANCH"),
 		"dir":              os.Getenv("BITBUCKET_CLONE_DIR"),
 		"repoUrl":          os.Getenv("BITBUCKET_GIT_HTTP_ORIGIN"),
 		"updateSequenceId": os.Getenv("BITBUCKET_BUILD_NUMBER"),

--- a/build/package/circleci/orb.yml
+++ b/build/package/circleci/orb.yml
@@ -51,7 +51,6 @@ commands:
               -repoType=${LD_REPO_TYPE} \
               -repoUrl=${LD_REPO_URL} \
               -repoName=${CIRCLE_PROJECT_REPONAME} \
-              -repoHead=${CIRCLE_BRANCH} \
               -updateSequenceId=${CIRCLE_BUILD_NUM} \
               -defaultBranch=${LD_DEFAULT_BRANCH} \
               -commitUrlTemplate=${LD_COMMIT_URL_TEMPLATE} \

--- a/build/package/circleci/orb.yml
+++ b/build/package/circleci/orb.yml
@@ -73,7 +73,7 @@ jobs:
         type: integer
         default: -1
       exclude:
-        description:  "A regular expression (PCRE) defining the files, file types, and directories which the job should exclude. Partial matches are allowed. Examples: `vendor/`, `vendor/.*`, `.*\\.css`"
+        description:  "A regular expression (PCRE) defining the files, file types, and directories which the job should exclude. Partial matches are allowed. Examples: `vendor/`, `\.css`, `vendor/|\.css`"
         type: string
         default: ""
       repo_type:

--- a/build/package/github-actions/github-actions.go
+++ b/build/package/github-actions/github-actions.go
@@ -27,7 +27,6 @@ func main() {
 	options := map[string]string{
 		"repoType":         "github",
 		"repoName":         ghRepo[1],
-		"repoHead":         os.Getenv("GITHUB_REF"),
 		"dir":              os.Getenv("GITHUB_WORKSPACE"),
 		"updateSequenceId": strconv.FormatInt(event.Repo.PushedAt*1000, 10), // seconds to milliseconds
 		"defaultBranch":    event.Repo.DefaultBranch,

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -9,8 +9,7 @@ import (
 
 type Git struct {
 	Workspace string
-	Head      string
-	RepoName  string
+	// Head      string
 }
 
 /*
@@ -22,8 +21,8 @@ Group 4: Line contents
 */
 var grepRegex, _ = regexp.Compile("([^:]+)(:|-)([0-9]+)[:-](.*)")
 
-func (g Git) RevParse() (string, error) {
-	cmd := exec.Command("git", "rev-parse", g.Head)
+func (g Git) BranchName() (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
 	cmd.Dir = g.Workspace
 	out, err := cmd.Output()
 	if err != nil {
@@ -32,20 +31,17 @@ func (g Git) RevParse() (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
-func (g Git) Clone(endpoint string) error {
-	cmd := exec.Command("git", "clone", "--depth", "1", "--single-branch", "--branch", g.Head, endpoint, g.Workspace)
-	err := cmd.Run()
-	return err
+func (g Git) RevParse(branch string) (string, error) {
+	cmd := exec.Command("git", "rev-parse", branch)
+	cmd.Dir = g.Workspace
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
 }
 
-func (g Git) Checkout() error {
-	checkout := exec.Command("git", "checkout", g.Head)
-	checkout.Dir = g.Workspace
-	err := checkout.Run()
-	return err
-}
-
-func (g Git) Grep(flags []string, ctxLines int) ([][]string, error) {
+func (g Git) SearchForFlags(flags []string, ctxLines int) ([][]string, error) {
 	var sb strings.Builder
 
 	sb.WriteString(fmt.Sprintf("ag --nogroup --case-sensitive"))
@@ -76,3 +72,16 @@ func (g Git) Grep(flags []string, ctxLines int) ([][]string, error) {
 	ret := grepRegexWithFilteredPath.FindAllStringSubmatch(string(out), -1)
 	return ret, err
 }
+
+// func (g Git) Clone(endpoint string) error {
+// 	cmd := exec.Command("git", "clone", "--depth", "1", "--single-branch", "--branch", g.Head, endpoint, g.Workspace)
+// 	err := cmd.Run()
+// 	return err
+// }
+
+// func (g Git) Checkout() error {
+// 	checkout := exec.Command("git", "checkout", g.Head)
+// 	checkout.Dir = g.Workspace
+// 	err := checkout.Run()
+// 	return err
+// }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -72,16 +72,3 @@ func (g Git) SearchForFlags(flags []string, ctxLines int) ([][]string, error) {
 	ret := grepRegexWithFilteredPath.FindAllStringSubmatch(string(out), -1)
 	return ret, err
 }
-
-// func (g Git) Clone(endpoint string) error {
-// 	cmd := exec.Command("git", "clone", "--depth", "1", "--single-branch", "--branch", g.Head, endpoint, g.Workspace)
-// 	err := cmd.Run()
-// 	return err
-// }
-
-// func (g Git) Checkout() error {
-// 	checkout := exec.Command("git", "checkout", g.Head)
-// 	checkout.Dir = g.Workspace
-// 	err := checkout.Run()
-// 	return err
-// }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -9,7 +9,6 @@ import (
 
 type Git struct {
 	Workspace string
-	// Head      string
 }
 
 /*
@@ -28,7 +27,11 @@ func (g Git) BranchName() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return strings.TrimSpace(string(out)), nil
+	ret := strings.TrimSpace(string(out))
+	if ret := "HEAD" {
+		return "", nil
+	}
+	return ret, nil
 }
 
 func (g Git) RevParse(branch string) (string, error) {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -28,7 +28,7 @@ func (g Git) BranchName() (string, error) {
 		return "", err
 	}
 	ret := strings.TrimSpace(string(out))
-	if ret := "HEAD" {
+	if ret == "HEAD" {
 		return "", nil
 	}
 	return ret, nil

--- a/internal/options/options.go
+++ b/internal/options/options.go
@@ -49,16 +49,14 @@ func (o Int64Option) Value() int64 {
 }
 
 const (
-	AccessToken = StringOption("accessToken")
-	BaseUri     = StringOption("baseUri")
-	// CloneEndpoint     = StringOption("cloneEndpoint")
+	AccessToken       = StringOption("accessToken")
+	BaseUri           = StringOption("baseUri")
 	ContextLines      = IntOption("contextLines")
 	DefaultBranch     = StringOption("defaultBranch")
 	Dir               = StringOption("dir")
 	Exclude           = StringOption("exclude")
 	ProjKey           = StringOption("projKey")
 	UpdateSequenceId  = Int64Option("updateSequenceId")
-	RepoHead          = StringOption("repoHead")
 	RepoName          = StringOption("repoName")
 	RepoType          = StringOption("repoType")
 	RepoUrl           = StringOption("repoUrl")
@@ -89,16 +87,14 @@ const (
 )
 
 var options = optionMap{
-	AccessToken: option{"", "LaunchDarkly personal access token with write-level access.", true},
-	BaseUri:     option{"https://app.launchdarkly.com", "LaunchDarkly base URI.", false},
-	// CloneEndpoint:     option{"", "If provided, will clone the repo from this endpoint. If authentication is required, this endpoint should be authenticated. Supports the https protocol for git cloning. Example: https://username:password@github.com/username/repository.git", false},
+	AccessToken:       option{"", "LaunchDarkly personal access token with write-level access.", true},
+	BaseUri:           option{"https://app.launchdarkly.com", "LaunchDarkly base URI.", false},
 	ContextLines:      option{noContextLines, "The number of context lines to send to LaunchDarkly. If < 0, no source code will be sent to LaunchDarkly. If 0, only the lines containing flag references will be sent. If > 0, will send that number of context lines above and below the flag reference. A maximum of 5 context lines may be provided.", false},
 	DefaultBranch:     option{"master", "The git default branch. The LaunchDarkly UI will default to this branch.", false},
 	Dir:               option{"", "Path to existing checkout of the git repo.", false},
 	Exclude:           option{"", `A regular expression (PCRE) defining the files and directories which the flag finder should exclude. Partial matches are allowed. Examples: "vendor/", "vendor/*`, false},
 	ProjKey:           option{"", "LaunchDarkly project key.", true},
 	UpdateSequenceId:  option{noUpdateSequenceId, `An integer representing the order number of code reference updates. Used to version updates across concurrent executions of the flag finder. If not provided, data will always be updated. If provided, data will only be updated if the existing "updateSequenceId" is less than the new "updateSequenceId". Examples: the time a "git push" was initiated, CI build number, the current unix timestamp.`, false},
-	RepoHead:          option{"master", "The branch to scan for code references. Should be provided if the `git push` was initiated on a non-master branch.", false},
 	RepoName:          option{"", `Git repo name. Will be displayed in LaunchDarkly. Case insensitive. Both a repo name and the repo name with an organization identifier are valid. Examples: "linux", "torvalds/linux."`, true},
 	RepoType:          option{"custom", "The repo service provider. Used to correctly categorize repositories in the LaunchDarkly UI. Aceptable values: github|bitbucket|custom.", false},
 	RepoUrl:           option{"", "The display url for the repository. If provided for a github or bitbucket repository, LaunchDarkly will attempt to automatically generate source code links.", false},

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -69,7 +69,7 @@ func Parse() {
 	currBranch, err := cmd.BranchName()
 	if err != nil {
 		log.Error.Fatalf("error parsing git branch name: %s", err)
-	} else if strings.ToUpper(currBranch) == "HEAD" || currBranch == "" {
+	} currBranch == "" {
 		log.Error.Fatalf("error parsing git branch name: git repo at %s must be checked out to a valid branch", cmd.Workspace)
 	}
 

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -64,29 +64,20 @@ func Parse() {
 		os.Exit(1)
 	}
 
-	currBranch := o.RepoHead.Value()
+	cmd := git.Git{Workspace: o.Dir.Value()}
 
-	cmd := git.Git{Workspace: o.Dir.Value(), Head: currBranch, RepoName: o.RepoName.Value()}
+	currBranch, err := cmd.BranchName()
+	if err != nil {
+		log.Error.Fatalf("error parsing git branch name: %s", err)
+	} else if strings.ToUpper(currBranch) == "HEAD" || currBranch == "" {
+		log.Error.Fatalf("error parsing git branch name: git repo at %s must be checked out to a valid branch", cmd.Workspace)
+	}
 
-	// TODO: Reintroduce this codepath if we decide the flag finder should be able to clone repos
-	// endpoint := o.CloneEndpoint.Value()
-	// if endpoint != "" {
-	// 	dir, err := ioutil.TempDir("", cmd.RepoName)
-	// 	if err != nil {
-	// 		fatal("Failed to create temp directory for repo clone", err)
-	// 	}
-	// 	defer os.RemoveAll(dir)
-	// 	cmd.Workspace = dir
-	// 	err = cmd.Clone(endpoint)
-	// 	if err != nil {
-	// 		fatal("Unable to clone repo", err)
-	// 	}
-	// }
-
-	headSha, err := cmd.RevParse()
+	headSha, err := cmd.RevParse(currBranch)
 	if err != nil {
 		log.Error.Fatalf("error parsing current commit sha: %s", err)
 	}
+
 	projKey := o.ProjKey.Value()
 	ldApi := ld.InitApiClient(ld.ApiOptions{ApiKey: o.AccessToken.Value(), BaseUri: o.BaseUri.Value(), ProjKey: projKey})
 	repoParams := ld.RepoParams{
@@ -177,12 +168,12 @@ func getFlags(ldApi ld.ApiClient) ([]string, error) {
 }
 
 func (b *branch) findReferences(cmd git.Git, flags []string, ctxLines int, exclude *regexp.Regexp) (grepResultLines, error) {
-	err := cmd.Checkout()
-	if err != nil {
-		return grepResultLines{}, err
-	}
+	// err := cmd.Checkout()
+	// if err != nil {
+	// 	return grepResultLines{}, err
+	// }
 
-	grepResult, err := cmd.Grep(flags, ctxLines)
+	grepResult, err := cmd.SearchForFlags(flags, ctxLines)
 	if err != nil {
 		return grepResultLines{}, err
 	}

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -168,11 +168,6 @@ func getFlags(ldApi ld.ApiClient) ([]string, error) {
 }
 
 func (b *branch) findReferences(cmd git.Git, flags []string, ctxLines int, exclude *regexp.Regexp) (grepResultLines, error) {
-	// err := cmd.Checkout()
-	// if err != nil {
-	// 	return grepResultLines{}, err
-	// }
-
 	grepResult, err := cmd.SearchForFlags(flags, ctxLines)
 	if err != nil {
 		return grepResultLines{}, err

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -69,7 +69,7 @@ func Parse() {
 	currBranch, err := cmd.BranchName()
 	if err != nil {
 		log.Error.Fatalf("error parsing git branch name: %s", err)
-	} currBranch == "" {
+	} else if currBranch == "" {
 		log.Error.Fatalf("error parsing git branch name: git repo at %s must be checked out to a valid branch", cmd.Workspace)
 	}
 


### PR DESCRIPTION
This PR removes the `repoHead` command line argument in effort to simplify the utility. 

Added new logic to infer the branch name using a special `git rev-parse` flag. 