### PR TITLE
set default contextLines to 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ ld-find-code-refs \
   -projKey="$YOUR_LAUNCHDARKLY_PROJECT_KEY" \
   -repoName="$YOUR_REPOSITORY_NAME" \
   -dir="/path/to/git/repo" \
-  -contextLines=3 # can be up to 5. -1 (or not configured) indicates no source code will be sent to LD
+  -contextLines=3 # can be up to 5. If < 0, no source code will be sent to LD
 ```
 
 The above configuration, with the `vendor/` directory and all `css` files ignored by the scanner. The `exclude` parameter may be configuration as any regular expression that matches the files and directories you'd like to ignore for your repository:
@@ -106,7 +106,7 @@ Although these arguments are optional, a (*) indicates a recommended parameter t
 | Option | Description | Default |
 |-|-|-|
 | `baseUri` | Set the base URL of the LaunchDarkly server for this configuration. Only necessary if using a private instance of LaunchDarkly. | `https://app.launchdarkly.com` |
-| `contextLines` (*) | The number of context lines to send to LaunchDarkly. If < 0, no source code will be sent to LaunchDarkly. If 0, only the line containing flag references will be sent. If > 0, will send that number of context lines above and below the flag reference. A maximum of 5 context lines may be provided. | `-1` |
+| `contextLines` (*) | The number of context lines to send to LaunchDarkly. If < 0, no source code will be sent to LaunchDarkly. If 0, only the line containing flag references will be sent. If > 0, will send that number of context lines above and below the flag reference. A maximum of 5 context lines may be provided. | `2` |
 | `defaultBranch` | The git default branch. The LaunchDarkly UI will default to display code references for this branch. | `master` |
 | `exclude` (*) | A regular expression (PCRE) defining the files and directories which the flag finder should exclude. Partial matches are allowed. Examples: `vendor/`, `\.css`, `vendor/\|\.css` | |
 | `updateSequenceId` | An integer representing the order number of code reference updates. Used to version updates across concurrent executions of the program. If not provided, data will always be updated. If provided, data will only be updated if the existing `updateSequenceId` is less than the new `updateSequenceId`. Examples: the time a `git push` was initiated, CI build number, the current unix timestamp. | |

--- a/build/package/circleci/orb.yml
+++ b/build/package/circleci/orb.yml
@@ -70,7 +70,7 @@ jobs:
       context_lines:
         description: The number of context lines above and below a code reference for the job to send to LaunchDarkly. By default, the flag finder will not send any context lines to LaunchDarkly. If < 0, no source code will be sent to LaunchDarkly. If 0, only the lines containing flag references will be sent. If > 0, will send that number of context lines above and below the flag reference. A maximum of 5 context lines may be provided.
         type: integer
-        default: -1
+        default: 2
       exclude:
         description:  "A regular expression (PCRE) defining the files, file types, and directories which the job should exclude. Partial matches are allowed. Examples: `vendor/`, `\.css`, `vendor/|\.css`"
         type: string

--- a/internal/options/options.go
+++ b/internal/options/options.go
@@ -82,14 +82,14 @@ func (m optionMap) find(name string) *option {
 }
 
 const (
-	noUpdateSequenceId = int64(-1)
-	noContextLines     = -1
+	noUpdateSequenceId  = int64(-1)
+	defaultContextLines = 2
 )
 
 var options = optionMap{
 	AccessToken:       option{"", "LaunchDarkly personal access token with write-level access.", true},
 	BaseUri:           option{"https://app.launchdarkly.com", "LaunchDarkly base URI.", false},
-	ContextLines:      option{noContextLines, "The number of context lines to send to LaunchDarkly. If < 0, no source code will be sent to LaunchDarkly. If 0, only the lines containing flag references will be sent. If > 0, will send that number of context lines above and below the flag reference. A maximum of 5 context lines may be provided.", false},
+	ContextLines:      option{defaultContextLines, "The number of context lines to send to LaunchDarkly. If < 0, no source code will be sent to LaunchDarkly. If 0, only the lines containing flag references will be sent. If > 0, will send that number of context lines above and below the flag reference. A maximum of 5 context lines may be provided.", false},
 	DefaultBranch:     option{"master", "The git default branch. The LaunchDarkly UI will default to this branch.", false},
 	Dir:               option{"", "Path to existing checkout of the git repo.", false},
 	Exclude:           option{"", `A regular expression (PCRE) defining the files and directories which the flag finder should exclude. Partial matches are allowed. Examples: "vendor/", "vendor/*`, false},
@@ -182,7 +182,7 @@ func GetLDOptionsFromEnv() (map[string]string, error) {
 	}
 
 	if ldOptions["contextLines"] == "" {
-		ldOptions["contextLines"] = "-1"
+		ldOptions["contextLines"] = "2"
 	}
 	_, err = strconv.ParseInt(ldOptions["contextLines"], 10, 32)
 	if err != nil {


### PR DESCRIPTION
Sets the default context lines count to 2. So, context lines are now opt-out.

Will follow-up this PR with doc updates.