### PR TITLE
Add debug command-line argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the ld-find-code-refs program will be documented in this 
 
 ### Added
 - Added support for relative paths to CLI `-dir` parameter.
+- Added a new command line argument, `debug`, which enables verbose debug logging.
 
 ## [0.3.0] - 2019-01-23
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Although these arguments are optional, a (*) indicates a recommended parameter t
 |-|-|-|
 | `baseUri` | Set the base URL of the LaunchDarkly server for this configuration. Only necessary if using a private instance of LaunchDarkly. | `https://app.launchdarkly.com` |
 | `contextLines` (*) | The number of context lines to send to LaunchDarkly. If < 0, no source code will be sent to LaunchDarkly. If 0, only the line containing flag references will be sent. If > 0, will send that number of context lines above and below the flag reference. A maximum of 5 context lines may be provided. | -1 |
-| `debug` | Enables verbose debug logging | `false` |
+| `debug` | Enables verbose debug logging. | `false` |
 | `defaultBranch` | The git default branch. The LaunchDarkly UI will default to display code references for this branch. | "master" |
 | `exclude` (*) | A regular expression (PCRE) defining the files and directories which the flag finder should exclude. Partial matches are allowed. Examples: `vendor/`, `\.css`, `vendor/|\.css` | "" |
 | `updateSequenceId` | An integer representing the order number of code reference updates. Used to version updates across concurrent executions of the program. If not provided, data will always be updated. If provided, data will only be updated if the existing `updateSequenceId` is less than the new `updateSequenceId`. Examples: the time a `git push` was initiated, CI build number, the current unix timestamp. | n/a |

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Although these arguments are optional, a (*) indicates a recommended parameter t
 |-|-|-|
 | `baseUri` | Set the base URL of the LaunchDarkly server for this configuration. Only necessary if using a private instance of LaunchDarkly. | `https://app.launchdarkly.com` |
 | `contextLines` (*) | The number of context lines to send to LaunchDarkly. If < 0, no source code will be sent to LaunchDarkly. If 0, only the line containing flag references will be sent. If > 0, will send that number of context lines above and below the flag reference. A maximum of 5 context lines may be provided. | -1 |
+| `debug` | Enables verbose debug logging | `false` |
 | `defaultBranch` | The git default branch. The LaunchDarkly UI will default to display code references for this branch. | "master" |
 | `exclude` (*) | A regular expression (PCRE) defining the files and directories which the flag finder should exclude. Partial matches are allowed. Examples: `vendor/`, `\.css`, `vendor/|\.css` | "" |
 | `updateSequenceId` | An integer representing the order number of code reference updates. Used to version updates across concurrent executions of the program. If not provided, data will always be updated. If provided, data will only be updated if the existing `updateSequenceId` is less than the new `updateSequenceId`. Examples: the time a `git push` was initiated, CI build number, the current unix timestamp. | n/a |

--- a/build/package/bitbucket-pipelines/bitbucket-pipelines.go
+++ b/build/package/bitbucket-pipelines/bitbucket-pipelines.go
@@ -10,8 +10,14 @@ import (
 )
 
 func main() {
-	log.Info.Printf("Setting Bitbucket action env vars")
+	debug, err := o.GetDebugOptionFromEnv()
+	// init logging before checking error because we need to log the error if there is one
+	log.Init(debug)
+	if err != nil {
+		log.Error.Fatalf("error parsing debug option: %s", err)
+	}
 
+	log.Info.Printf("setting Bitbucket Pipelines env vars")
 	options := map[string]string{
 		"repoType":         "bitbucket",
 		"repoName":         os.Getenv("BITBUCKET_REPO_SLUG"),
@@ -31,9 +37,10 @@ func main() {
 	for k, v := range options {
 		err := flag.Set(k, v)
 		if err != nil {
-			log.Error.Fatalf("Error setting option %s: %s", k, err)
+			log.Error.Fatalf("error setting option %s: %s", k, err)
 		}
 	}
-	log.Info.Printf("Starting repo parsing program with options:\n %+v\n", options)
+	log.Info.Printf("starting repo parsing program with options:\n %+v\n", options)
+
 	parse.Parse()
 }

--- a/build/package/github-actions/github-actions.go
+++ b/build/package/github-actions/github-actions.go
@@ -14,6 +14,13 @@ import (
 )
 
 func main() {
+	debug, err := o.GetDebugOptionFromEnv()
+	// init logging before checking error because we need to log the error if there is one
+	log.Init(debug)
+	if err != nil {
+		log.Error.Fatalf("error parsing debug option: %s", err)
+	}
+
 	log.Info.Printf("Setting GitHub action env vars")
 	ghRepo := strings.Split(os.Getenv("GITHUB_REPOSITORY"), "/")
 	if len(ghRepo) < 2 {

--- a/cmd/ld-find-code-refs/main.go
+++ b/cmd/ld-find-code-refs/main.go
@@ -1,7 +1,21 @@
 package main
 
-import "github.com/launchdarkly/ld-find-code-refs/pkg/parse"
+import (
+	"os"
+
+	"github.com/launchdarkly/ld-find-code-refs/internal/log"
+	o "github.com/launchdarkly/ld-find-code-refs/internal/options"
+	"github.com/launchdarkly/ld-find-code-refs/pkg/parse"
+)
 
 func main() {
+	err, cb := o.Init()
+	if err != nil {
+		log.Init(false)
+		log.Error.Printf("could not validate command line options: %s", err)
+		cb()
+		os.Exit(1)
+	}
+	log.Init(o.Debug.Value())
 	parse.Parse()
 }

--- a/internal/ld/ld.go
+++ b/internal/ld/ld.go
@@ -362,7 +362,7 @@ func (b BranchRep) PrintReferenceCountTable() {
 			additionalRefCount += i
 		}
 	}
-	truncatedData = append(truncatedData, []string{"Other Flags", strconv.FormatInt(additionalRefCount, 10)})
+	truncatedData = append(truncatedData, []string{"Other flags", strconv.FormatInt(additionalRefCount, 10)})
 
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader([]string{"Flag", "# References"})

--- a/internal/ld/ld_test.go
+++ b/internal/ld/ld_test.go
@@ -3,10 +3,18 @@ package ld
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/launchdarkly/ld-find-code-refs/internal/log"
 )
+
+func TestMain(m *testing.M) {
+	log.InitLogging(true)
+	os.Exit(m.Run())
+}
 
 func TestPostCodeReferenceRepository(t *testing.T) {
 	specs := []struct {

--- a/internal/ld/ld_test.go
+++ b/internal/ld/ld_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	log.InitLogging(true)
+	log.Init(true)
 	os.Exit(m.Run())
 }
 

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -1,8 +1,9 @@
 package log
 
 import (
-	"io"
+	"io/ioutil"
 	"log"
+	"os"
 )
 
 // Global package level loggers
@@ -13,26 +14,26 @@ var (
 	Error   *log.Logger
 )
 
-// InitLogging overrides the default loggers that write to stdout
-func InitLogging(
-	debugHandle io.Writer,
-	infoHandle io.Writer,
-	warningHandle io.Writer,
-	errorHandle io.Writer) {
+// Init overrides the default loggers that write to stdout
+func Init(debug bool) {
+	debugHandle := ioutil.Discard
+	if debug {
+		debugHandle = os.Stdout
+	}
 
 	Debug = log.New(debugHandle,
 		"DEBUG: ",
 		log.Ldate|log.Ltime|log.Lshortfile)
 
-	Info = log.New(infoHandle,
+	Info = log.New(os.Stdout,
 		"INFO: ",
 		log.Ldate|log.Ltime|log.Lshortfile)
 
-	Warning = log.New(warningHandle,
+	Warning = log.New(os.Stdout,
 		"WARNING: ",
 		log.Ldate|log.Ltime|log.Lshortfile)
 
-	Error = log.New(errorHandle,
+	Error = log.New(os.Stderr,
 		"ERROR: ",
 		log.Ldate|log.Ltime|log.Lshortfile)
 }

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -3,7 +3,6 @@ package log
 import (
 	"io"
 	"log"
-	"os"
 )
 
 // Global package level loggers
@@ -13,10 +12,6 @@ var (
 	Warning *log.Logger
 	Error   *log.Logger
 )
-
-func init() {
-	InitLogging(os.Stdout, os.Stdout, os.Stdout, os.Stderr)
-}
 
 // InitLogging overrides the default loggers that write to stdout
 func InitLogging(

--- a/internal/options/options.go
+++ b/internal/options/options.go
@@ -211,7 +211,7 @@ func GetLDOptionsFromEnv() (map[string]string, error) {
 }
 
 func GetDebugOptionFromEnv() (bool, error) {
-	debug := os.Getenv("debug")
+	debug := os.Getenv("LD_DEBUG")
 	if debug == "" {
 		return false, nil
 	}

--- a/internal/options/options.go
+++ b/internal/options/options.go
@@ -187,7 +187,13 @@ func GetLDOptionsFromEnv() (map[string]string, error) {
 		"exclude":      os.Getenv("LD_EXCLUDE"),
 		"contextLines": os.Getenv("LD_CONTEXT_LINES"),
 		"baseUri":      os.Getenv("LD_BASE_URI"),
+		"debug":        os.Getenv("LD_DEBUG"),
 	}
+
+	if ldOptions["debug"] == "" {
+		ldOptions["debug"] = "false"
+	}
+
 	_, err := regexp.Compile(ldOptions["exclude"])
 	if err != nil {
 		return ldOptions, fmt.Errorf("couldn't parse LD_EXCLUDE as regex: %+v", err)
@@ -202,4 +208,12 @@ func GetLDOptionsFromEnv() (map[string]string, error) {
 	}
 
 	return ldOptions, nil
+}
+
+func GetDebugOptionFromEnv() (bool, error) {
+	debug := os.Getenv("debug")
+	if debug == "" {
+		return false, nil
+	}
+	return strconv.ParseBool(debug)
 }

--- a/internal/options/options.go
+++ b/internal/options/options.go
@@ -18,6 +18,7 @@ type Option interface {
 type StringOption string
 type IntOption string
 type Int64Option string
+type BoolOption string
 
 func (o StringOption) name() string {
 	return string(o)
@@ -26,6 +27,9 @@ func (o IntOption) name() string {
 	return string(o)
 }
 func (o Int64Option) name() string {
+	return string(o)
+}
+func (o BoolOption) name() string {
 	return string(o)
 }
 
@@ -48,10 +52,15 @@ func (o Int64Option) Value() int64 {
 	return flag.Lookup(string(o)).Value.(flag.Getter).Get().(int64)
 }
 
+func (o BoolOption) Value() bool {
+	return flag.Lookup(string(o)).Value.(flag.Getter).Get().(bool)
+}
+
 const (
 	AccessToken       = StringOption("accessToken")
 	BaseUri           = StringOption("baseUri")
 	ContextLines      = IntOption("contextLines")
+	Debug             = BoolOption("debug")
 	DefaultBranch     = StringOption("defaultBranch")
 	Dir               = StringOption("dir")
 	Exclude           = StringOption("exclude")
@@ -92,6 +101,7 @@ var options = optionMap{
 	ContextLines:      option{noContextLines, "The number of context lines to send to LaunchDarkly. If < 0, no source code will be sent to LaunchDarkly. If 0, only the lines containing flag references will be sent. If > 0, will send that number of context lines above and below the flag reference. A maximum of 5 context lines may be provided.", false},
 	DefaultBranch:     option{"master", "The git default branch. The LaunchDarkly UI will default to this branch.", false},
 	Dir:               option{"", "Path to existing checkout of the git repo.", false},
+	Debug:             option{false, "Enables verbose debug logging", false},
 	Exclude:           option{"", `A regular expression (PCRE) defining the files and directories which the flag finder should exclude. Partial matches are allowed. Examples: "vendor/", "vendor/*`, false},
 	ProjKey:           option{"", "LaunchDarkly project key.", true},
 	UpdateSequenceId:  option{noUpdateSequenceId, `An integer representing the order number of code reference updates. Used to version updates across concurrent executions of the flag finder. If not provided, data will always be updated. If provided, data will only be updated if the existing "updateSequenceId" is less than the new "updateSequenceId". Examples: the time a "git push" was initiated, CI build number, the current unix timestamp.`, false},
@@ -164,6 +174,8 @@ func Populate() {
 			flag.Int(name, v, o.usage)
 		case string:
 			flag.String(name, v, o.usage)
+		case bool:
+			flag.Bool(name, v, o.usage)
 		}
 	}
 }

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -2,7 +2,6 @@ package parse
 
 import (
 	"container/list"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strconv"
@@ -58,22 +57,6 @@ type branch struct {
 	UpdateSequenceId *int64
 	SyncTime         int64
 	GrepResults      grepResultLines
-}
-
-func init() {
-	err, cb := o.Init()
-	if err != nil {
-		log.Error.Printf("could not validate command line options: %s", err)
-		cb()
-		os.Exit(1)
-	}
-
-	debugOut := ioutil.Discard
-	if o.Debug.Value() {
-		debugOut = os.Stdout
-	}
-
-	log.InitLogging(debugOut, os.Stdout, os.Stdout, os.Stderr)
 }
 
 func Parse() {


### PR DESCRIPTION
Adds the optional `debug` command line argument. If enabled, enables debug logging. The pretty-printed table of flag keys to ref counts now requires debug logging to be printed.