### PR TITLE
add openssh dependency to CLI docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to the ld-find-code-refs program will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
 ## [0.3.0] - 2019-01-23
+
+### Added
+- Added openssh as a dependency for the command-line docker image.
+
 ### Changed
 - The default for `contextLines` is now 2. To disable sending source code to LaunchDarkly, set the `contextLines` argument to `-1`.
 - Improved logging to provide more detailed summaries of actions performed by the scanner.

--- a/build/package/cmd/Dockerfile
+++ b/build/package/cmd/Dockerfile
@@ -3,5 +3,6 @@ FROM alpine:3.8
 RUN apk update
 RUN apk add --no-cache git
 RUN apk add --no-cache the_silver_searcher
+RUN apk add --no-cache openssh
 
 COPY ld-find-code-refs /usr/local/bin/ld-find-code-refs


### PR DESCRIPTION
Readd the openssh dependency for the base docker image in case any consumers require ssh for cloning their git repository