### PR TITLE
Allow passing relative paths for -dir parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the ld-find-code-refs program will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
+## Master
+
+### Added
+- Added support for relative paths to CLI `-dir` parameter.
+
 ## [0.3.0] - 2019-01-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ A number of command-line arguments are available to the code ref finder, some op
 | Option | Description |
 |-|-|
 | `accessToken` | LaunchDarkly [personal access token](https://docs.launchdarkly.com/docs/api-access-tokens) with writer-level access, or access to the `code-reference-repository` [custom role](https://docs.launchdarkly.com/v2.0/docs/custom-roles) resource |
-| `dir` | **Absolute** path to existing checkout of the git repo. Relative paths are not currently supported. The currently checked out branch will be scanned for code references. |
+| `dir` | Path to existing checkout of the git repo. The currently checked out branch will be scanned for code references. |
 | `projKey` | A LaunchDarkly project key. |
 | `repoName` | Git repo name. Will be displayed in LaunchDarkly. Repo names must only contain letters, numbers, '.', '_' or '-'." |
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -39,11 +39,12 @@ func (g Git) BranchName() (string, error) {
 func (g Git) RevParse(branch string) (string, error) {
 	cmd := exec.Command("git", "-C", g.Workspace, "rev-parse", branch)
 	out, err := cmd.Output()
-	log.Debug.Printf("identified sha: %s", strings.TrimSpace(string(out)))
 	if err != nil {
 		return "", err
 	}
-	return strings.TrimSpace(string(out)), nil
+	ret := strings.TrimSpace(string(out))
+	log.Debug.Printf("identified sha: %s", ret)
+	return ret, nil
 }
 
 func (g Git) SearchForFlags(flags []string, ctxLines int) ([][]string, error) {

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -72,7 +72,6 @@ func Parse() {
 	absPath, err := normalizeAndValidatePath(o.Dir.Value())
 	if err != nil {
 		log.Error.Fatalf("could not validate directory option: %s", err)
-		os.Exit(1)
 	}
 
 	cmd := git.Git{Workspace: absPath}

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -2,7 +2,9 @@ package parse
 
 import (
 	"container/list"
+	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -67,7 +69,13 @@ func Parse() {
 		os.Exit(1)
 	}
 
-	cmd := git.Git{Workspace: o.Dir.Value()}
+	absPath, err := normalizeAndValidatePath(o.Dir.Value())
+	if err != nil {
+		log.Error.Fatalf("could not validate directory option: %s", err)
+		os.Exit(1)
+	}
+
+	cmd := git.Git{Workspace: absPath}
 
 	currBranch, err := cmd.BranchName()
 	if err != nil {
@@ -158,6 +166,39 @@ func Parse() {
 			log.Error.Fatalf("error sending code references to LaunchDarkly: %s", err)
 		}
 	}
+}
+
+func normalizeAndValidatePath(path string) (string, error) {
+	absPath, err := filepath.Abs(o.Dir.Value())
+	if err != nil {
+		return "", fmt.Errorf("invalid directory: %s", err)
+	}
+	log.Info.Printf("absolute directory path: %s", absPath)
+
+	exists, err := dirExists(absPath)
+	if err != nil {
+		return "", fmt.Errorf("invalid directory: %s", err)
+	}
+
+	if !exists {
+		return "", fmt.Errorf("directory does not exist: %s", absPath)
+	}
+
+	return absPath, nil
+}
+
+func dirExists(path string) (bool, error) {
+	fileInfo, err := os.Stat(path)
+
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return fileInfo.Mode().IsDir(), nil
 }
 
 // Very short flag keys lead to many false positives when searching in code,


### PR DESCRIPTION
Makes the CLI much more ergonomic as typing out the absolute path can be annoying.

Adds another error check - does the directory exist. Without this error check you get a generic error message from git when you try to get the branch name which was confusing.

### Success Example:
```
../ld-find-code-refs/out/ld-find-code-refs -dir . -repoName=victest -projKey coderefs -accessToken api-d78ecb83-861d-4a27-ac83-5b68dca265eb -baseUri http://localhost
INFO: 2019/01/24 16:58:42 parse.go:69: absolute directory path: /Users/victor/src/go/src/github.com/launchdarkly/gonfalon
DEBUG: 2019/01/24 16:58:42 git.go:32: identified branch name: master
DEBUG: 2019/01/24 16:58:42 git.go:42: identified sha: edf1f7cc66e3cb893ca52a4ba7f87c6f599cfc8f
DEBUG: 2019/01/24 16:58:42 client.go:344: [DEBUG] GET http://localhost/api/v2/code-refs/repositories/victest
INFO: 2019/01/24 16:58:42 parse.go:177: sending 7 code references across 1 flags and 6 files to LaunchDarkly for project: coderefs
       FLAG       | # REFERENCES
+-----------------+--------------+
  enable.debugger |            7
  Other Flags     |            0
DEBUG: 2019/01/24 16:58:42 client.go:344: [DEBUG] PUT http://localhost/api/v2/code-refs/repositories/victest/branches/master
```

### Failure Example:
```
../ld-find-code-refs/out/ld-find-code-refs -dir xx -repoName=victest -projKey coderefs -accessToken api-d78ecb83-861d-4a27-ac83-5b68dca265eb -baseUri http://localhost
INFO: 2019/01/24 17:01:00 parse.go:69: absolute directory path: /Users/victor/src/go/src/github.com/launchdarkly/gonfalon/xx
ERROR: 2019/01/24 17:01:00 parse.go:93: could not validate directory option: directory does not exist: /Users/victor/src/go/src/github.com/launchdarkly/gonfalon/xx
```

https://app.clubhouse.io/launchdarkly/story/29752/git-flag-parser-dir-param-not-expanding-relative-paths