### PR TITLE
exit early if dependencies are not installed

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"errors"
 	"fmt"
 	"os/exec"
 	"regexp"
@@ -8,10 +9,6 @@ import (
 
 	"github.com/launchdarkly/ld-find-code-refs/internal/log"
 )
-
-type Git struct {
-	Workspace string
-}
 
 /*
 grepRegex splits resulting grep lines into groups
@@ -21,6 +18,24 @@ Group 3: Line number
 Group 4: Line contents
 */
 var grepRegex, _ = regexp.Compile("([^:]+)(:|-)([0-9]+)[:-](.*)")
+
+type Git struct {
+	Workspace string
+}
+
+func NewClient(path string) (Git, error) {
+	client := Git{path}
+	_, err := exec.LookPath("git")
+	if err != nil {
+		return client, errors.New("git is a required dependency, but was not found in the system PATH")
+	}
+	_, err = exec.LookPath("ag")
+	if err != nil {
+		return client, errors.New("ag (The Silver Searcher) is a required dependency, but was not found in the system PATH")
+	}
+
+	return client, nil
+}
 
 func (g Git) BranchName() (string, error) {
 	cmd := exec.Command("git", "-C", g.Workspace, "rev-parse", "--abbrev-ref", "HEAD")

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -67,7 +67,10 @@ func Parse() {
 		log.Error.Fatalf("could not validate directory option: %s", err)
 	}
 
-	cmd := git.Git{Workspace: absPath}
+	cmd, err := git.NewClient(absPath)
+	if err != nil {
+		log.Error.Fatalf("error: %s", err)
+	}
 
 	currBranch, err := cmd.BranchName()
 	if err != nil {
@@ -86,9 +89,9 @@ func Parse() {
 	// Check for potential sdk keys or access tokens provided as the project key
 	if len(projKey) > maxProjKeyLength {
 		if strings.HasPrefix(projKey, "sdk-") {
-			log.Warning.Printf("Provided projKey (%s) appears to be a LaunchDarkly SDK key", "sdk-xxxx")
+			log.Warning.Printf("provided projKey (%s) appears to be a LaunchDarkly SDK key", "sdk-xxxx")
 		} else if strings.HasPrefix(projKey, "api-") {
-			log.Warning.Printf("Provided projKey (%s) appears to be a LaunchDarkly API access token", "api-xxxx")
+			log.Warning.Printf("provided projKey (%s) appears to be a LaunchDarkly API access token", "api-xxxx")
 		}
 	}
 


### PR DESCRIPTION
Check for `ag` and `git` on system PATH before running the scanner.

Followup pr coming to rename the `git` package to something more generic