### PR TITLE
Automate publishing to homebrew tap.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,24 +20,25 @@ release:
 brew:
   name: ld-find-code-refs
 
+  description: "Enables you to keep track of feature flag usage in your code from LaunchDarkly."
+
+  homepage: "https://launchdarkly.com"
+
   github:
     owner: launchdarkly
     name: homebrew-tap-test
 
-  url_template: "http://github.com/launchdarkly/ld-find-code-refs/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
-
-  commit_author:
-    name: goreleaserbot
-    email: dev@launchdarkly.com
-
   folder: Formula
 
-  caveats: "Enables you to keep track of feature flag usage in your code from LaunchDarkly."
-
-  homepage: "https://launchdarkly.com"
+  url_template: "http://github.com/launchdarkly/ld-find-code-refs/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
 
   dependencies:
     - "ag"
 
   install: |
     bin.install "ld-find-code-refs"
+
+  commit_author:
+    name: goreleaserbot
+    email: dev@launchdarkly.com
+

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,3 +17,27 @@ release:
   # If set to true, will mark the release as not ready for production.
   prerelease: auto
 
+brew:
+  name: ld-find-code-refs
+
+  github:
+    owner: launchdarkly
+    name: homebrew-tap-test
+
+  url_template: "http://github.com/launchdarkly/ld-find-code-refs/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+
+  commit_author:
+    name: goreleaserbot
+    email: dev@launchdarkly.com
+
+  folder: Formula
+
+  caveats: "Enables you to keep track of feature flag usage in your code from LaunchDarkly."
+
+  homepage: "https://launchdarkly.com"
+
+  dependencies:
+    - "ag"
+
+  install: |
+    bin.install "ld-find-code-refs"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the ld-find-code-refs program will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [0.4.1] - 2019-01-31
+### Changed
+- Automate Homebrew releases
+
 ## [0.4.0] - 2019-01-30
 
 ### Added

--- a/build/package/circleci/orb.yml
+++ b/build/package/circleci/orb.yml
@@ -33,7 +33,7 @@ executors:
       LD_HUNK_URL_TEMPLATE: << parameters.hunk_url_template >>
       LD_DEFAULT_BRANCH: << parameters.default_branch >>
     docker:
-      - image: launchdarkly/ld-find-code-refs:0.4.0
+      - image: launchdarkly/ld-find-code-refs:0.4.1
 commands:
   find-flags:
     steps:


### PR DESCRIPTION
I tested this by locally releasing to https://github.com/launchdarkly/homebrew-tap-test/blob/master/Formula/ld-find-code-refs.rb. 

Its not a perfect test but it's close enough. Going to do a 0.4.1 release to officially test this though.