### PR TITLE
Generate deb and rpm packages.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
+      - run: sudo apt-get install rpm
       - run: curl -sL https://git.io/goreleaser | bash -s -- --rm-dist --skip-publish --skip-validate --release-notes <(make echo-release-notes)
 
   publish:
@@ -83,6 +84,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
+      - run: sudo apt-get install rpm
       - run: curl -sL https://git.io/goreleaser | bash -s -- --rm-dist --release-notes <(make echo-release-notes)
 
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -55,6 +55,6 @@ brew:
     bin.install "ld-find-code-refs"
 
   commit_author:
-    name: goreleaserbot
+    name: LaunchDarklyCI
     email: dev@launchdarkly.com
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,22 @@ builds:
       - 386
       - amd64
 
+nfpm:
+  name_template: "{{ .ProjectName }}_{{ .Version }}.{{ .Arch }}"
+
+  homepage: https://launchdarkly.com/
+  maintainer: LaunchDarkly <team@launchdarkly.com>
+  description: Job for finding and sending feature flag code references to LaunchDarkly
+  license: Apache 2.0
+  vendor: LaunchDarkly
+
+  formats:
+  - deb
+  - rpm
+
+  replacements:
+    386: i386
+
 release:
   # If set to auto, will mark the release as not ready for production
   # in case there is an indicator for this in the tag e.g. v1.0.0-rc1
@@ -20,7 +36,7 @@ release:
 brew:
   name: ld-find-code-refs
 
-  description: "Job for finding and sending feature flag code references to LaunchDarkly"
+  description: Job for finding and sending feature flag code references to LaunchDarkly
 
   homepage: "https://launchdarkly.com"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable changes to the ld-find-code-refs program will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [0.5.0] - 2019-02-01
 ### Added
 - Generate deb and rpm packages when releasing artifacts.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the ld-find-code-refs program will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
+### Added
+- Generate deb and rpm packages when releasing artifacts.
+
 ### Changed
 - Automate Homebrew releases
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,24 @@ brew install ld-find-code-refs
 
 You can now run `ld-find-code-refs`.
 
+#### Linux
+We do not yet have repositories set up for our linux packages, but we do upload deb and rpm packages with our github releases. 
+
+##### Ubuntu
+This shell script can be used to download and install `ag` and `ld-find-code-refs` on Ubuntu.
+
+```shell
+apt-get install silversearcher-ag
+
+wget -qO- https://api.github.com/repos/launchdarkly/ld-find-code-refs/releases/latest \
+	| grep "browser_download_url" \
+	| grep "amd64.deb" \
+	| cut -d'"' -f4 \
+	| wget -qi - -O ld-find-code-refs.amd64.deb
+
+dpkg -i ld-find-code-refs.amd64.deb
+```
+
 #### Manual
 
 Precompiled binaries for the latest release can be found [here](https://github.com/launchdarkly/ld-find-code-refs/releases/latest).

--- a/build/package/circleci/orb.yml
+++ b/build/package/circleci/orb.yml
@@ -33,7 +33,7 @@ executors:
       LD_HUNK_URL_TEMPLATE: << parameters.hunk_url_template >>
       LD_DEFAULT_BRANCH: << parameters.default_branch >>
     docker:
-      - image: launchdarkly/ld-find-code-refs:0.4.0
+      - image: launchdarkly/ld-find-code-refs:0.5.0
 commands:
   find-flags:
     steps:


### PR DESCRIPTION
Use goreleaser to generate deb and rpm packages.

**Note 1:** Goreleaser lets us specify deb/rpm dependencies. I tried to specify ag as a dependency, but was not able to get the install working correctly. Deb dependencies assume you're installing with a package manager, `dpkg` can't install `ag` for you. I saw a fixup command online (`apt-get install -f`) thats supposed to find broken dependencies and install them for you, but it didn't work in my test. It just tried to delete `ld-find-code-refs`. So the installation instructions for linux will specify to `apt-get install silversearcher-ag` (and whatever the appropriate install command is for yum). Or maybe just link to ag's linux install instructions.

**Note 2:** The ubuntu shell script in the readme won't work as is because github's release api doesn't return preleases for the `/latest` endpoint. I tested it like this though:
```shell
root@f70dd16ddab3:/# wget -qO- https://api.github.com/repos/launchdarkly/ld-find-code-refs/releases/tags/0.5.0-rc1 | grep "browser_download_url" | grep "amd64.deb" | cut -d'"' -f4 | wget -qi - -O ld-find-code-refs.deb
root@f70dd16ddab3:/# ls
bin  boot  dev  etc  home  ld-find-code-refs.deb  lib  lib64  media  mnt  opt  proc  root  run  sbin  srv  sys  tmp  usr  var
root@f70dd16ddab3:/# dpkg -i ld-find-code-refs.deb
(Reading database ... 4382 files and directories currently installed.)
Preparing to unpack ld-find-code-refs.deb ...
Unpacking ld-find-code-refs (0.5.0-rc1) over (0.5.0-rc1) ...
Setting up ld-find-code-refs (0.5.0-rc1) ...
```

## TODO
- [x] Test debian release locally (in a docker image)
- [x] Test by publishing a release candidate
- [x] After test, update README with installation instructions