### PR TITLE
Wrap flag keys in word boundary characters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the ld-find-code-refs program will be documented in this 
 
 ### Changed
 - Automate Homebrew releases
+- Added word boundaries to flag key regexes.
+  - This should reduce false positives. E.g. for flag key `cool-feature` we will no longer match `verycool-features`.
 
 ## [0.4.0] - 2019-01-30
 

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -95,11 +95,12 @@ func (c Client) SearchForFlags(flags []string, ctxLines int) ([][]string, error)
 		sb.WriteString(fmt.Sprintf(" -C%d", ctxLines))
 	}
 
-	escapedFlags := []string{}
+	flagRegexes := []string{}
 	for _, v := range flags {
-		escapedFlags = append(escapedFlags, regexp.QuoteMeta(v))
+		escapedFlag := regexp.QuoteMeta(v)
+		flagRegexes = append(flagRegexes, "\\b"+escapedFlag+"\\b")
 	}
-	sb.WriteString(" '" + strings.Join(escapedFlags, "|") + "' " + c.Workspace)
+	sb.WriteString(" '" + strings.Join(flagRegexes, "|") + "' " + c.Workspace)
 
 	cmd := sb.String()
 	sh := exec.Command("sh", "-c", cmd)


### PR DESCRIPTION
This will eliminate a couple of cases of false positive matches, namely: 
- when either end of the flag key has a letter or number
- when either end of the flag key has an underscore.

It'l still match when `-`, `.`, and any other punctuation on either end. I think optimizing this behavior is a rabbit hole for now so we should stick with easy `\b`. 

**Note:** For this change to have maximum impact, we should update frontend highlighting code to use the same regex.

I've QA'd this on a number of our internal repos and confirmed there aren't any regressions (to the best of my knowledge).