### PR TITLE
http -> https when goreleasing to brew

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,7 +46,7 @@ brew:
 
   folder: Formula
 
-  url_template: "http://github.com/launchdarkly/ld-find-code-refs/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+  url_template: "https://github.com/launchdarkly/ld-find-code-refs/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
 
   dependencies:
     - "ag"


### PR DESCRIPTION
will open a PR to retroactively fix 0.5.0 in our homebrew-tap