### PR TITLE
move default branch field to repo rep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,20 @@
 
 All notable changes to the ld-find-code-refs program will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
+## Master
+
+### Changed
+
+- The internal API for specifying the default git branch (`defaultBranch`) has been changed. The `defaultBranch` argument on earlier versions of `ld-find-code-refs` will no longer do anything.
+
 ## [0.5.0] - 2019-02-01
+
 ### Added
+
 - Generate deb and rpm packages when releasing artifacts.
 
 ### Changed
+
 - Automate Homebrew releases
 - Added word boundaries to flag key regexes.
   - This should reduce false positives. E.g. for flag key `cool-feature` we will no longer match `verycool-features`.
@@ -14,45 +23,57 @@ All notable changes to the ld-find-code-refs program will be documented in this 
 ## [0.4.0] - 2019-01-30
 
 ### Added
+
 - Added support for relative paths to CLI `-dir` parameter.
 - Added a new command line argument, `debug`, which enables verbose debug logging.
 - `ld-find-code-refs` will now exit early if required dependencies are not installed on the system PATH.
 
 ### Changed
+
 - Renamed `parse` package to `coderefs`. The `Parse()` method in the aformentioned package is now `Scan()`.
 
 ### Fixed
-- `ld-find-code-refs` will no longer erroneously make PATCH API requests to LaunchDarkly when url template parameters have not been configured.
 
+- `ld-find-code-refs` will no longer erroneously make PATCH API requests to LaunchDarkly when url template parameters have not been configured.
 
 ## [0.3.0] - 2019-01-23
 
 ### Added
+
 - Added openssh as a dependency for the command-line docker image.
 
 ### Changed
+
 - The default for `contextLines` is now 2. To disable sending source code to LaunchDarkly, set the `contextLines` argument to `-1`.
 - Improved logging to provide more detailed summaries of actions performed by the scanner.
 
 ### Fixed
+
 - Fixed a bug in the CircleCI orb config causing `contextLines` to be a string parameter, instead of an integer.
 
 ### Removed
+
 - Removed the `repoHead` parameter. `ld-find-code-refs` now only supports scanning repositories already checked out to the desired branch.
 - Removed an unnecessary dependency on openssh in Dockerfiles.
 
 ## [0.2.1] - 2019-01-17
+
 ### Fixed
+
 - Fix a bug causing an error to be returned when a repository connection to LaunchDarkly does not initially exist on execution.
 
 ### Removed
+
 - Removed the `cloneEndpoint` command line argument. `ld-find-code-refs` now only supports scanning existing repository clones.
 
 ## [0.2.0] - 2019-01-16
+
 ### Fixed
+
 - Use case-sensitive `ag` search so we don't get false positives that look like flag keys but have different casing.
 
 ### Changed
+
 - This project has been renamed to `ld-find-code-refs`.
 - Logging has been overhauled.
 - Project layout has been updated to comply with https://github.com/golang-standards/project-layout.
@@ -67,14 +88,19 @@ All notable changes to the ld-find-code-refs program will be documented in this 
 - Use `launchdarkly` docker hub namespace instead of `ldactions`.
 
 ## [0.1.0] - 2019-01-02
+
 ### Changed
+
 - `pushTime` CLI arg renamed to `updateSequenceId`. Its type has been changed from timestamp to integer.
   - Note: this is not considered a breaking change as the CLI args are still in flux. After the 1.0 release arg changes will be considered breaking.
 
 ### Fixed
+
 - Upserting repos no longer fails on non-existent repos
 
 ## [0.0.1] - 2018-12-14
+
 ### Added
+
 - Automated release pipeline for github releases and docker images
 - Changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,19 +3,14 @@
 All notable changes to the ld-find-code-refs program will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
 ## Master
-
 ### Changed
-
 - The internal API for specifying the default git branch (`defaultBranch`) has been changed. The `defaultBranch` argument on earlier versions of `ld-find-code-refs` will no longer do anything.
 
 ## [0.5.0] - 2019-02-01
-
 ### Added
-
 - Generate deb and rpm packages when releasing artifacts.
 
 ### Changed
-
 - Automate Homebrew releases
 - Added word boundaries to flag key regexes.
   - This should reduce false positives. E.g. for flag key `cool-feature` we will no longer match `verycool-features`.
@@ -23,57 +18,45 @@ All notable changes to the ld-find-code-refs program will be documented in this 
 ## [0.4.0] - 2019-01-30
 
 ### Added
-
 - Added support for relative paths to CLI `-dir` parameter.
 - Added a new command line argument, `debug`, which enables verbose debug logging.
 - `ld-find-code-refs` will now exit early if required dependencies are not installed on the system PATH.
 
 ### Changed
-
 - Renamed `parse` package to `coderefs`. The `Parse()` method in the aformentioned package is now `Scan()`.
 
 ### Fixed
-
 - `ld-find-code-refs` will no longer erroneously make PATCH API requests to LaunchDarkly when url template parameters have not been configured.
+
 
 ## [0.3.0] - 2019-01-23
 
 ### Added
-
 - Added openssh as a dependency for the command-line docker image.
 
 ### Changed
-
 - The default for `contextLines` is now 2. To disable sending source code to LaunchDarkly, set the `contextLines` argument to `-1`.
 - Improved logging to provide more detailed summaries of actions performed by the scanner.
 
 ### Fixed
-
 - Fixed a bug in the CircleCI orb config causing `contextLines` to be a string parameter, instead of an integer.
 
 ### Removed
-
 - Removed the `repoHead` parameter. `ld-find-code-refs` now only supports scanning repositories already checked out to the desired branch.
 - Removed an unnecessary dependency on openssh in Dockerfiles.
 
 ## [0.2.1] - 2019-01-17
-
 ### Fixed
-
 - Fix a bug causing an error to be returned when a repository connection to LaunchDarkly does not initially exist on execution.
 
 ### Removed
-
 - Removed the `cloneEndpoint` command line argument. `ld-find-code-refs` now only supports scanning existing repository clones.
 
 ## [0.2.0] - 2019-01-16
-
 ### Fixed
-
 - Use case-sensitive `ag` search so we don't get false positives that look like flag keys but have different casing.
 
 ### Changed
-
 - This project has been renamed to `ld-find-code-refs`.
 - Logging has been overhauled.
 - Project layout has been updated to comply with https://github.com/golang-standards/project-layout.
@@ -88,19 +71,14 @@ All notable changes to the ld-find-code-refs program will be documented in this 
 - Use `launchdarkly` docker hub namespace instead of `ldactions`.
 
 ## [0.1.0] - 2019-01-02
-
 ### Changed
-
 - `pushTime` CLI arg renamed to `updateSequenceId`. Its type has been changed from timestamp to integer.
   - Note: this is not considered a breaking change as the CLI args are still in flux. After the 1.0 release arg changes will be considered breaking.
 
 ### Fixed
-
 - Upserting repos no longer fails on non-existent repos
 
 ## [0.0.1] - 2018-12-14
-
 ### Added
-
 - Automated release pipeline for github releases and docker images
 - Changelog

--- a/internal/ld/ld.go
+++ b/internal/ld/ld.go
@@ -176,6 +176,7 @@ func (c ApiClient) MaybeUpsertCodeReferenceRepository(repo RepoParams) error {
 			Url:               currentRepo.Url,
 			CommitUrlTemplate: currentRepo.CommitUrlTemplate,
 			HunkUrlTemplate:   currentRepo.HunkUrlTemplate,
+			DefaultBranch:     currentRepo.DefaultBranch,
 		}
 
 		// Don't patch templates if command line arguments are not provided.
@@ -187,6 +188,11 @@ func (c ApiClient) MaybeUpsertCodeReferenceRepository(repo RepoParams) error {
 			if repo.HunkUrlTemplate == "" {
 				currentRepoParams.HunkUrlTemplate = ""
 			}
+		}
+
+		// If defaultBranch is absent and repo already exists, do nothing
+		if currentRepoParams.DefaultBranch == "" {
+			currentRepoParams.DefaultBranch = repo.DefaultBranch
 		}
 
 		if !reflect.DeepEqual(currentRepoParams, repo) {
@@ -294,6 +300,7 @@ type RepoParams struct {
 	Url               string `json:"sourceLink"`
 	CommitUrlTemplate string `json:"commitUrlTemplate"`
 	HunkUrlTemplate   string `json:"hunkUrlTemplate"`
+	DefaultBranch     string `json:"defaultBranch"`
 }
 
 type RepoRep struct {
@@ -302,6 +309,7 @@ type RepoRep struct {
 	Url               string `json:"sourceLink"`
 	CommitUrlTemplate string `json:"commitUrlTemplate"`
 	HunkUrlTemplate   string `json:"hunkUrlTemplate"`
+	DefaultBranch     string `json:"defaultBranch"`
 	Enabled           bool   `json:"enabled,omitempty"`
 }
 type BranchRep struct {
@@ -309,7 +317,6 @@ type BranchRep struct {
 	Head             string              `json:"head"`
 	UpdateSequenceId *int64              `json:"updateSequenceId,omitempty"`
 	SyncTime         int64               `json:"syncTime"`
-	IsDefault        bool                `json:"isDefault"`
 	References       []ReferenceHunksRep `json:"references,omitempty"`
 }
 

--- a/internal/options/options.go
+++ b/internal/options/options.go
@@ -99,7 +99,7 @@ var options = optionMap{
 	AccessToken:       option{"", "LaunchDarkly personal access token with write-level access.", true},
 	BaseUri:           option{"https://app.launchdarkly.com", "LaunchDarkly base URI.", false},
 	ContextLines:      option{defaultContextLines, "The number of context lines to send to LaunchDarkly. If < 0, no source code will be sent to LaunchDarkly. If 0, only the lines containing flag references will be sent. If > 0, will send that number of context lines above and below the flag reference. A maximum of 5 context lines may be provided.", false},
-	DefaultBranch:     option{"master", "The git default branch. The LaunchDarkly UI will default to this branch.", false},
+	DefaultBranch:     option{"", "The git default branch. The LaunchDarkly UI will default to this branch. If not provided, will fallback to `master`.", false},
 	Dir:               option{"", "Path to existing checkout of the git repo.", false},
 	Debug:             option{false, "Enables verbose debug logging", false},
 	Exclude:           option{"", `A regular expression (PCRE) defining the files and directories which the flag finder should exclude. Partial matches are allowed. Examples: "vendor/", "vendor/*`, false},

--- a/pkg/coderefs/coderefs.go
+++ b/pkg/coderefs/coderefs.go
@@ -53,7 +53,6 @@ type fileGrepResults struct {
 type branch struct {
 	Name             string
 	Head             string
-	IsDefault        bool
 	UpdateSequenceId *int64
 	SyncTime         int64
 	GrepResults      grepResultLines
@@ -83,6 +82,7 @@ func Scan() {
 		Url:               o.RepoUrl.Value(),
 		CommitUrlTemplate: o.CommitUrlTemplate.Value(),
 		HunkUrlTemplate:   o.HunkUrlTemplate.Value(),
+		DefaultBranch:     o.DefaultBranch.Value(),
 	}
 
 	err = ldApi.MaybeUpsertCodeReferenceRepository(repoParams)
@@ -116,7 +116,6 @@ func Scan() {
 	}
 	b := &branch{
 		Name:             cmd.GitBranch,
-		IsDefault:        o.DefaultBranch.Value() == cmd.GitBranch,
 		UpdateSequenceId: updateId,
 		SyncTime:         makeTimestamp(),
 		Head:             cmd.GitSha,
@@ -223,7 +222,6 @@ func (b *branch) makeBranchRep(projKey string, ctxLines int) ld.BranchRep {
 		Head:             b.Head,
 		UpdateSequenceId: b.UpdateSequenceId,
 		SyncTime:         b.SyncTime,
-		IsDefault:        b.IsDefault,
 		References:       b.GrepResults.makeReferenceHunksReps(projKey, ctxLines),
 	}
 }


### PR DESCRIPTION
changes internal behavior to send the default branch on the repo rep instead of as a `is_default` boolean on the branch rep.