### PR TITLE
add version command line argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,20 @@
 
 All notable changes to the ld-find-code-refs program will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
-## [0.5.0] - 2019-02-01
+## Master
+
 ### Added
+
+- Added a new command line argument, `version`. If provided, the current `ld-find-code-refs` version number will be logged, and the scanner will exit with a return code of 0.
+
+## [0.5.0] - 2019-02-01
+
+### Added
+
 - Generate deb and rpm packages when releasing artifacts.
 
 ### Changed
+
 - Automate Homebrew releases
 - Added word boundaries to flag key regexes.
   - This should reduce false positives. E.g. for flag key `cool-feature` we will no longer match `verycool-features`.
@@ -14,45 +23,57 @@ All notable changes to the ld-find-code-refs program will be documented in this 
 ## [0.4.0] - 2019-01-30
 
 ### Added
+
 - Added support for relative paths to CLI `-dir` parameter.
 - Added a new command line argument, `debug`, which enables verbose debug logging.
 - `ld-find-code-refs` will now exit early if required dependencies are not installed on the system PATH.
 
 ### Changed
+
 - Renamed `parse` package to `coderefs`. The `Parse()` method in the aformentioned package is now `Scan()`.
 
 ### Fixed
-- `ld-find-code-refs` will no longer erroneously make PATCH API requests to LaunchDarkly when url template parameters have not been configured.
 
+- `ld-find-code-refs` will no longer erroneously make PATCH API requests to LaunchDarkly when url template parameters have not been configured.
 
 ## [0.3.0] - 2019-01-23
 
 ### Added
+
 - Added openssh as a dependency for the command-line docker image.
 
 ### Changed
+
 - The default for `contextLines` is now 2. To disable sending source code to LaunchDarkly, set the `contextLines` argument to `-1`.
 - Improved logging to provide more detailed summaries of actions performed by the scanner.
 
 ### Fixed
+
 - Fixed a bug in the CircleCI orb config causing `contextLines` to be a string parameter, instead of an integer.
 
 ### Removed
+
 - Removed the `repoHead` parameter. `ld-find-code-refs` now only supports scanning repositories already checked out to the desired branch.
 - Removed an unnecessary dependency on openssh in Dockerfiles.
 
 ## [0.2.1] - 2019-01-17
+
 ### Fixed
+
 - Fix a bug causing an error to be returned when a repository connection to LaunchDarkly does not initially exist on execution.
 
 ### Removed
+
 - Removed the `cloneEndpoint` command line argument. `ld-find-code-refs` now only supports scanning existing repository clones.
 
 ## [0.2.0] - 2019-01-16
+
 ### Fixed
+
 - Use case-sensitive `ag` search so we don't get false positives that look like flag keys but have different casing.
 
 ### Changed
+
 - This project has been renamed to `ld-find-code-refs`.
 - Logging has been overhauled.
 - Project layout has been updated to comply with https://github.com/golang-standards/project-layout.
@@ -67,14 +88,19 @@ All notable changes to the ld-find-code-refs program will be documented in this 
 - Use `launchdarkly` docker hub namespace instead of `ldactions`.
 
 ## [0.1.0] - 2019-01-02
+
 ### Changed
+
 - `pushTime` CLI arg renamed to `updateSequenceId`. Its type has been changed from timestamp to integer.
   - Note: this is not considered a breaking change as the CLI args are still in flux. After the 1.0 release arg changes will be considered breaking.
 
 ### Fixed
+
 - Upserting repos no longer fails on non-existent repos
 
 ## [0.0.1] - 2018-12-14
+
 ### Added
+
 - Automated release pipeline for github releases and docker images
 - Changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,19 +3,14 @@
 All notable changes to the ld-find-code-refs program will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
 ## Master
-
 ### Added
-
 - Added a new command line argument, `version`. If provided, the current `ld-find-code-refs` version number will be logged, and the scanner will exit with a return code of 0.
 
 ## [0.5.0] - 2019-02-01
-
 ### Added
-
 - Generate deb and rpm packages when releasing artifacts.
 
 ### Changed
-
 - Automate Homebrew releases
 - Added word boundaries to flag key regexes.
   - This should reduce false positives. E.g. for flag key `cool-feature` we will no longer match `verycool-features`.
@@ -23,57 +18,45 @@ All notable changes to the ld-find-code-refs program will be documented in this 
 ## [0.4.0] - 2019-01-30
 
 ### Added
-
 - Added support for relative paths to CLI `-dir` parameter.
 - Added a new command line argument, `debug`, which enables verbose debug logging.
 - `ld-find-code-refs` will now exit early if required dependencies are not installed on the system PATH.
 
 ### Changed
-
 - Renamed `parse` package to `coderefs`. The `Parse()` method in the aformentioned package is now `Scan()`.
 
 ### Fixed
-
 - `ld-find-code-refs` will no longer erroneously make PATCH API requests to LaunchDarkly when url template parameters have not been configured.
+
 
 ## [0.3.0] - 2019-01-23
 
 ### Added
-
 - Added openssh as a dependency for the command-line docker image.
 
 ### Changed
-
 - The default for `contextLines` is now 2. To disable sending source code to LaunchDarkly, set the `contextLines` argument to `-1`.
 - Improved logging to provide more detailed summaries of actions performed by the scanner.
 
 ### Fixed
-
 - Fixed a bug in the CircleCI orb config causing `contextLines` to be a string parameter, instead of an integer.
 
 ### Removed
-
 - Removed the `repoHead` parameter. `ld-find-code-refs` now only supports scanning repositories already checked out to the desired branch.
 - Removed an unnecessary dependency on openssh in Dockerfiles.
 
 ## [0.2.1] - 2019-01-17
-
 ### Fixed
-
 - Fix a bug causing an error to be returned when a repository connection to LaunchDarkly does not initially exist on execution.
 
 ### Removed
-
 - Removed the `cloneEndpoint` command line argument. `ld-find-code-refs` now only supports scanning existing repository clones.
 
 ## [0.2.0] - 2019-01-16
-
 ### Fixed
-
 - Use case-sensitive `ag` search so we don't get false positives that look like flag keys but have different casing.
 
 ### Changed
-
 - This project has been renamed to `ld-find-code-refs`.
 - Logging has been overhauled.
 - Project layout has been updated to comply with https://github.com/golang-standards/project-layout.
@@ -88,19 +71,14 @@ All notable changes to the ld-find-code-refs program will be documented in this 
 - Use `launchdarkly` docker hub namespace instead of `ldactions`.
 
 ## [0.1.0] - 2019-01-02
-
 ### Changed
-
 - `pushTime` CLI arg renamed to `updateSequenceId`. Its type has been changed from timestamp to integer.
   - Note: this is not considered a breaking change as the CLI args are still in flux. After the 1.0 release arg changes will be considered breaking.
 
 ### Fixed
-
 - Upserting repos no longer fails on non-existent repos
 
 ## [0.0.1] - 2018-12-14
-
 ### Added
-
 - Automated release pipeline for github releases and docker images
 - Changelog

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,7 +1,7 @@
 # Releasing
 
 ## Versioning
-This project adheres to [Semantic Versioning](http://semver.org). Release version tags should be in the form `MAJOR.MINOR.PATCH`, with no leading v.
+This project adheres to [Semantic Versioning](http://semver.org). Release version tags should be in the form `MAJOR.MINOR.PATCH`, with no leading v. When releasing, be sure to update the version number in [`version.go`](https://github.com/launchdarkly/ld-find-code-refs/blob/master/internal/version/version.go)
 
 ## Github Releases
 

--- a/internal/ld/ld.go
+++ b/internal/ld/ld.go
@@ -29,10 +29,11 @@ type ApiClient struct {
 }
 
 type ApiOptions struct {
-	ApiKey   string
-	ProjKey  string
-	BaseUri  string
-	RetryMax *int
+	ApiKey    string
+	ProjKey   string
+	BaseUri   string
+	UserAgent string
+	RetryMax  *int
 }
 
 const (
@@ -65,7 +66,7 @@ func InitApiClient(options ApiOptions) ApiClient {
 	return ApiClient{
 		ldClient: ldapi.NewAPIClient(&ldapi.Configuration{
 			BasePath:  options.BaseUri + v2ApiPath,
-			UserAgent: "github-actor",
+			UserAgent: options.UserAgent,
 		}),
 		httpClient: client,
 		Options:    options,
@@ -123,6 +124,7 @@ func (c ApiClient) getCodeReferenceRepository(name string) (*RepoRep, error) {
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("User-Agent", c.Options.UserAgent)
 	res, err := c.do(req)
 	if err != nil {
 		return nil, err

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -12,6 +12,7 @@ var (
 	Info    *log.Logger
 	Warning *log.Logger
 	Error   *log.Logger
+	Stdout  *log.Logger
 )
 
 // Init overrides the default loggers that write to stdout
@@ -36,4 +37,6 @@ func Init(debug bool) {
 	Error = log.New(os.Stderr,
 		"ERROR: ",
 		log.Ldate|log.Ltime|log.Lshortfile)
+
+	Stdout = log.New(os.Stdout, "", 0)
 }

--- a/internal/options/options.go
+++ b/internal/options/options.go
@@ -8,6 +8,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/launchdarkly/ld-find-code-refs/internal/version"
 )
 
 // Can't wait for contracts
@@ -140,6 +142,11 @@ func Init() (err error, errCb func()) {
 			}
 		}
 	})
+
+	fmt.Printf("ld-find-code-refs version %s", version.Version)
+	if Version.Value() {
+		os.Exit(0)
+	}
 
 	if opt != "" {
 		return fmt.Errorf("required option %s not set", opt), flag.PrintDefaults

--- a/internal/options/options.go
+++ b/internal/options/options.go
@@ -71,6 +71,7 @@ const (
 	RepoUrl           = StringOption("repoUrl")
 	CommitUrlTemplate = StringOption("commitUrlTemplate")
 	HunkUrlTemplate   = StringOption("hunkUrlTemplate")
+	Version           = BoolOption("version")
 )
 
 type option struct {
@@ -110,6 +111,7 @@ var options = optionMap{
 	RepoUrl:           option{"", "The display url for the repository. If provided for a github or bitbucket repository, LaunchDarkly will attempt to automatically generate source code links.", false},
 	CommitUrlTemplate: option{"", "If provided, LaunchDarkly will attempt to generate links to your Git service provider per commit. Example: `https://github.com/launchdarkly/ld-find-code-refs/commit/${sha}`. Allowed template variables: `branchName`, `sha`. If `commitUrlTemplate` is not provided, but `repoUrl` is provided and `repoType` is not custom, LaunchDarkly will automatically generate links to the repository for each commit.", false},
 	HunkUrlTemplate:   option{"", "If provided, LaunchDarkly will attempt to generate links to your Git service provider per code reference. Example: `https://github.com/launchdarkly/ld-find-code-refs/blob/${sha}/${filePath}#L${lineNumber}`. Allowed template variables: `sha`, `filePath`, `lineNumber`. If `hunkUrlTemplate` is not provided, but repoUrl is provided and `repoType` is not custom, LaunchDarkly will automatically generate links to the repository for each code reference.", false},
+	Version:           option{false, "If provided, the scanner will print the version number and exit early", false},
 }
 
 // Init reads specified options and exits if options of invalid types or unspecified options were provided.

--- a/internal/options/options.go
+++ b/internal/options/options.go
@@ -143,7 +143,7 @@ func Init() (err error, errCb func()) {
 		}
 	})
 
-	fmt.Printf("ld-find-code-refs version %s", version.Version)
+	fmt.Println("ld-find-code-refs version", version.Version)
 	if Version.Value() {
 		os.Exit(0)
 	}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,3 @@
+package version
+
+const Version = "0.6.0"

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "0.6.0"
+const Version = "0.5.0"

--- a/pkg/coderefs/coderefs.go
+++ b/pkg/coderefs/coderefs.go
@@ -20,6 +20,8 @@ import (
 // PUTing a massive json payload. These limits will likely be tweaked over
 // time. The LaunchDarkly backend will also apply limits.
 const (
+	version = "0.6.0"
+
 	minFlagKeyLen                     = 3
 	maxFileCount                      = 5000
 	maxLineCharCount                  = 500
@@ -60,6 +62,10 @@ type branch struct {
 }
 
 func Scan() {
+	log.Stdout.Printf("ld-find-code-refs version " + version)
+	if o.Version.Value() {
+		return
+	}
 	cmd, err := command.NewClient(o.Dir.Value())
 	if err != nil {
 		log.Error.Fatalf("%s", err)
@@ -76,7 +82,7 @@ func Scan() {
 		}
 	}
 
-	ldApi := ld.InitApiClient(ld.ApiOptions{ApiKey: o.AccessToken.Value(), BaseUri: o.BaseUri.Value(), ProjKey: projKey})
+	ldApi := ld.InitApiClient(ld.ApiOptions{ApiKey: o.AccessToken.Value(), BaseUri: o.BaseUri.Value(), ProjKey: projKey, UserAgent: "LDFindCodeRefs/" + version})
 	repoParams := ld.RepoParams{
 		Type:              o.RepoType.Value(),
 		Name:              o.RepoName.Value(),

--- a/pkg/coderefs/coderefs.go
+++ b/pkg/coderefs/coderefs.go
@@ -12,6 +12,7 @@ import (
 	"github.com/launchdarkly/ld-find-code-refs/internal/ld"
 	"github.com/launchdarkly/ld-find-code-refs/internal/log"
 	o "github.com/launchdarkly/ld-find-code-refs/internal/options"
+	"github.com/launchdarkly/ld-find-code-refs/internal/version"
 )
 
 // These are defensive limits intended to prevent corner cases stemming from
@@ -20,8 +21,6 @@ import (
 // PUTing a massive json payload. These limits will likely be tweaked over
 // time. The LaunchDarkly backend will also apply limits.
 const (
-	version = "0.6.0"
-
 	minFlagKeyLen                     = 3
 	maxFileCount                      = 5000
 	maxLineCharCount                  = 500
@@ -62,10 +61,6 @@ type branch struct {
 }
 
 func Scan() {
-	log.Stdout.Printf("ld-find-code-refs version " + version)
-	if o.Version.Value() {
-		return
-	}
 	cmd, err := command.NewClient(o.Dir.Value())
 	if err != nil {
 		log.Error.Fatalf("%s", err)
@@ -82,7 +77,7 @@ func Scan() {
 		}
 	}
 
-	ldApi := ld.InitApiClient(ld.ApiOptions{ApiKey: o.AccessToken.Value(), BaseUri: o.BaseUri.Value(), ProjKey: projKey, UserAgent: "LDFindCodeRefs/" + version})
+	ldApi := ld.InitApiClient(ld.ApiOptions{ApiKey: o.AccessToken.Value(), BaseUri: o.BaseUri.Value(), ProjKey: projKey, UserAgent: "LDFindCodeRefs/" + version.Version})
 	repoParams := ld.RepoParams{
 		Type:              o.RepoType.Value(),
 		Name:              o.RepoName.Value(),


### PR DESCRIPTION
`ld-find-code-refs` will now always log the current version number to stdout. If the `version` argument is provided, `ld-find-code-refs` will immediately terminate after logging the version number.