### PR TITLE
log an error when no hunks were made for a reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the ld-find-code-refs program will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
+## Master
+### Fixed
+- `ld-find-code-refs` will no longer error out if an unknown error occurs when scanning for code reference hunks within a file. Instead, an error will be logged.
+
 ## [0.5.0] - 2019-02-01
 ### Added
 - Generate deb and rpm packages when releasing artifacts.

--- a/pkg/coderefs/coderefs.go
+++ b/pkg/coderefs/coderefs.go
@@ -248,6 +248,12 @@ func (g grepResultLines) makeReferenceHunksReps(projKey string, ctxLines int) []
 
 		hunks := fileGrepResults.makeHunkReps(projKey, ctxLines)
 
+		if len(hunks) == 0 {
+			log.Error.Printf("unknown error scanning for code references in %s", fileGrepResults.path)
+			log.Debug.Printf("%+v", fileGrepResults)
+			continue
+		}
+
 		if len(hunks) > maxHunksPerFileCount {
 			log.Warning.Printf("found %d code references in %s, which exceeded the limit of %d, truncating file hunks", len(hunks), fileGrepResults.path, maxHunksPerFileCount)
 			hunks = hunks[0:maxHunksPerFileCount]
@@ -412,7 +418,7 @@ func buildHunksForFlag(projKey, flag, path string, flagReferences []*list.Elemen
 		// If we have written more than the max. allowed number of lines for this file and flag, finish this hunk and exit early.
 		// This guards against a situation where the user has very long files with many false positive matches.
 		if numHunkedLines > maxHunkedLinesPerFileAndFlagCount {
-			log.Warning.Printf("Found %d code reference lines in %s for the flag %s, which exceeded the limit of %d. Truncating code references for this path and flag.",
+			log.Warning.Printf("found %d code reference lines in %s for the flag %s, which exceeded the limit of %d. truncating code references for this path and flag.",
 				numHunkedLines, path, flag, maxHunkedLinesPerFileAndFlagCount)
 			return hunks
 		}

--- a/pkg/coderefs/coderefs.go
+++ b/pkg/coderefs/coderefs.go
@@ -248,7 +248,7 @@ func (g grepResultLines) makeReferenceHunksReps(projKey string, ctxLines int) []
 		hunks := fileGrepResults.makeHunkReps(projKey, ctxLines)
 
 		if len(hunks) == 0 {
-			log.Error.Printf("unknown error scanning for code references in %s", fileGrepResults.path)
+			log.Error.Printf("expected code references but found none in '%s'", fileGrepResults.path)
 			log.Debug.Printf("%+v", fileGrepResults)
 			continue
 		}


### PR DESCRIPTION
This PR adds a helper log message in case we run into an error generating hunks. This shouldn't ever happen, but if it does, this log will help us debug any potential issues.