### PR TITLE
Prepare 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 All notable changes to the ld-find-code-refs program will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
-## Master
-
+## [0.6.0] - 2019-02-11
 ### Added
 - Added a new command line argument, `version`. If provided, the current `ld-find-code-refs` version number will be logged, and the scanner will exit with a return code of 0.
 - The `debug` option is now available to the CircleCI orb.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,6 +9,8 @@ This project uses [goreleaser](https://goreleaser.com/) to generate github relea
 
 Make sure you update the changelog before generating a release.
 
+Once a release has been completed, update the [BitBucket pipelines](https://bitbucket.org/launchdarkly/ld-find-code-refs-pipe) repo with the new version number, and push a tag containing the version number along with your commit. Example release commit: https://bitbucket.org/launchdarkly/ld-find-code-refs-pipe/commits/0b1e920c7322cd495f4fc1a09d339342d32606e4
+
 ## Docker Hub
 
 To push a new image version to Docker hub, run `make publish-cli-docker TAG=$VERSION` or `make publish-github-actions-docker TAG=$VERSION`, where `$VERSION` is the version you want to release. This will compile the ld-find-code-refs binary for either the base command line code ref finder or the github actions specialized finder, build a new image with your version tagged, and also point latest at that tag and push both latest and $VERSION to docker hub.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,7 +1,7 @@
 # Releasing
 
 ## Versioning
-This project adheres to [Semantic Versioning](http://semver.org). Release version tags should be in the form `MAJOR.MINOR.PATCH`, with no leading v. When releasing, be sure to update the version number in [`version.go`](https://github.com/launchdarkly/ld-find-code-refs/blob/master/internal/version/version.go)
+This project adheres to [Semantic Versioning](http://semver.org). Release version tags should be in the form `MAJOR.MINOR.PATCH`, with no leading v. When releasing, be sure to update the version number in [`version.go`](https://github.com/launchdarkly/ld-find-code-refs/blob/master/internal/version/version.go), and in the [CircleCI orb](https://github.com/launchdarkly/ld-find-code-refs/blob/master/build/package/circleci/orb.yml).
 
 ## Github Releases
 

--- a/build/package/circleci/orb.yml
+++ b/build/package/circleci/orb.yml
@@ -7,7 +7,7 @@ examples:
     usage:
       version: 2.1
       orbs:
-        launchdarkly: launchdarkly/ld-find-code-refs@0.5.0
+        launchdarkly: launchdarkly/ld-find-code-refs@0.6.0
       workflows:
         main:
           jobs:
@@ -21,7 +21,7 @@ examples:
     usage:
       version: 2.1
       orbs:
-        launchdarkly: launchdarkly/ld-find-code-refs@0.5.0
+        launchdarkly: launchdarkly/ld-find-code-refs@0.6.0
       workflows:
         main:
           jobs:
@@ -36,7 +36,7 @@ examples:
     usage:
       version: 2.1
       orbs:
-        launchdarkly: launchdarkly/ld-find-code-refs@0.5.0
+        launchdarkly: launchdarkly/ld-find-code-refs@0.6.0
       workflows:
         main:
           jobs:
@@ -52,7 +52,7 @@ examples:
     usage:
       version: 2.1
       orbs:
-        launchdarkly: launchdarkly/ld-find-code-refs@0.5.0
+        launchdarkly: launchdarkly/ld-find-code-refs@0.6.0
       workflows:
         main:
           jobs:
@@ -113,7 +113,7 @@ jobs:
         type: boolean
         default: false
     docker:
-      - image: launchdarkly/ld-find-code-refs:0.5.0
+      - image: launchdarkly/ld-find-code-refs:0.6.0
     steps:
       - checkout:
           path: /repo

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "0.5.0"
+const Version = "0.6.0"


### PR DESCRIPTION
## [0.6.0] - 2019-02-11
### Added
- Added a new command line argument, `version`. If provided, the current `ld-find-code-refs` version number will be logged, and the scanner will exit with a return code of 0.
- The `debug` option is now available to the CircleCI orb.
- Added support for parsing `.ldignore` files specified in the root directory of the scanned repository. `.ldignore` may be used to specify a pattern (compatible with the `.gitignore` spec: https://git-scm.com/docs/gitignore#_pattern_format) for files to exclude from scanning.

### Changed
- The internal API for specifying the default git branch (`defaultBranch`) has been changed. The `defaultBranch` argument on earlier versions of `ld-find-code-refs` will no longer do anything.

### Fixed
- `ld-find-code-refs` will no longer error out if an unknown error occurs when scanning for code reference hunks within a file. Instead, an error will be logged.