### PR TITLE
make dir argument required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the ld-find-code-refs program will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
+## Master
+### Fixed
+- The `dir` command line option was marked as optional, but is actually required. `ld-find-code-refs` will now recognize this option as required.
+
 ## [0.6.0] - 2019-02-11
 ### Added
 - Added a new command line argument, `version`. If provided, the current `ld-find-code-refs` version number will be logged, and the scanner will exit with a return code of 0.

--- a/internal/options/options.go
+++ b/internal/options/options.go
@@ -103,7 +103,7 @@ var options = optionMap{
 	BaseUri:           option{"https://app.launchdarkly.com", "LaunchDarkly base URI.", false},
 	ContextLines:      option{defaultContextLines, "The number of context lines to send to LaunchDarkly. If < 0, no source code will be sent to LaunchDarkly. If 0, only the lines containing flag references will be sent. If > 0, will send that number of context lines above and below the flag reference. A maximum of 5 context lines may be provided.", false},
 	DefaultBranch:     option{"", "The git default branch. The LaunchDarkly UI will default to this branch. If not provided, will fallback to `master`.", false},
-	Dir:               option{"", "Path to existing checkout of the git repo.", false},
+	Dir:               option{"", "Path to existing checkout of the git repo.", true},
 	Debug:             option{false, "Enables verbose debug logging", false},
 	Exclude:           option{"", `A regular expression (PCRE) defining the files and directories which the flag finder should exclude. Partial matches are allowed. Examples: "vendor/", "\.css`, false},
 	ProjKey:           option{"", "LaunchDarkly project key.", true},


### PR DESCRIPTION
The `dir` command line option was marked as optional, but is actually required. This should not be a breaking change, because the CLI would fail on execution if a `dir` was not provided.