### PR TITLE
add windows support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,12 +1,13 @@
 builds:
   -
-    binary: ld-find-code-refs/
+    binary: ld-find-code-refs
     main: ./cmd/ld-find-code-refs/
     env:
       - CGO_ENABLED=0
     goos:
       - darwin
       - linux
+      - windows
     goarch:
       - 386
       - amd64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,29 +3,43 @@
 All notable changes to the ld-find-code-refs program will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
 ## Master
+
+### Added
+
+- Added support for Windows. `ld-find-code-refs` releases will now contain a windows executable.
+
 ### Fixed
+
 - The `dir` command line option was marked as optional, but is actually required. `ld-find-code-refs` will now recognize this option as required.
 
 ## [0.6.0] - 2019-02-11
+
 ### Added
+
 - Added a new command line argument, `version`. If provided, the current `ld-find-code-refs` version number will be logged, and the scanner will exit with a return code of 0.
 - The `debug` option is now available to the CircleCI orb.
 - Added support for parsing `.ldignore` files specified in the root directory of the scanned repository. `.ldignore` may be used to specify a pattern (compatible with the `.gitignore` spec: https://git-scm.com/docs/gitignore#_pattern_format) for files to exclude from scanning.
 
 ### Changed
+
 - The internal API for specifying the default git branch (`defaultBranch`) has been changed. The `defaultBranch` argument on earlier versions of `ld-find-code-refs` will no longer do anything.
 
 ### Fixed
+
 - `ld-find-code-refs` will no longer error out if an unknown error occurs when scanning for code reference hunks within a file. Instead, an error will be logged.
 
 ## [0.5.0] - 2019-02-01
+
 ### Master
+
 - Added support for parsing `.ldignore` files specified in the root directory of the scanned repository. `.ldignore` may be used to specify a pattern (compatible with the `.gitignore` spec: https://git-scm.com/docs/gitignore#_pattern_format) for files to exclude from scanning.
 
 ### Added
+
 - Generate deb and rpm packages when releasing artifacts.
 
 ### Changed
+
 - Automate Homebrew releases
 - Added word boundaries to flag key regexes.
   - This should reduce false positives. E.g. for flag key `cool-feature` we will no longer match `verycool-features`.
@@ -33,45 +47,57 @@ All notable changes to the ld-find-code-refs program will be documented in this 
 ## [0.4.0] - 2019-01-30
 
 ### Added
+
 - Added support for relative paths to CLI `-dir` parameter.
 - Added a new command line argument, `debug`, which enables verbose debug logging.
 - `ld-find-code-refs` will now exit early if required dependencies are not installed on the system PATH.
 
 ### Changed
+
 - Renamed `parse` package to `coderefs`. The `Parse()` method in the aformentioned package is now `Scan()`.
 
 ### Fixed
-- `ld-find-code-refs` will no longer erroneously make PATCH API requests to LaunchDarkly when url template parameters have not been configured.
 
+- `ld-find-code-refs` will no longer erroneously make PATCH API requests to LaunchDarkly when url template parameters have not been configured.
 
 ## [0.3.0] - 2019-01-23
 
 ### Added
+
 - Added openssh as a dependency for the command-line docker image.
 
 ### Changed
+
 - The default for `contextLines` is now 2. To disable sending source code to LaunchDarkly, set the `contextLines` argument to `-1`.
 - Improved logging to provide more detailed summaries of actions performed by the scanner.
 
 ### Fixed
+
 - Fixed a bug in the CircleCI orb config causing `contextLines` to be a string parameter, instead of an integer.
 
 ### Removed
+
 - Removed the `repoHead` parameter. `ld-find-code-refs` now only supports scanning repositories already checked out to the desired branch.
 - Removed an unnecessary dependency on openssh in Dockerfiles.
 
 ## [0.2.1] - 2019-01-17
+
 ### Fixed
+
 - Fix a bug causing an error to be returned when a repository connection to LaunchDarkly does not initially exist on execution.
 
 ### Removed
+
 - Removed the `cloneEndpoint` command line argument. `ld-find-code-refs` now only supports scanning existing repository clones.
 
 ## [0.2.0] - 2019-01-16
+
 ### Fixed
+
 - Use case-sensitive `ag` search so we don't get false positives that look like flag keys but have different casing.
 
 ### Changed
+
 - This project has been renamed to `ld-find-code-refs`.
 - Logging has been overhauled.
 - Project layout has been updated to comply with https://github.com/golang-standards/project-layout.
@@ -86,14 +112,19 @@ All notable changes to the ld-find-code-refs program will be documented in this 
 - Use `launchdarkly` docker hub namespace instead of `ldactions`.
 
 ## [0.1.0] - 2019-01-02
+
 ### Changed
+
 - `pushTime` CLI arg renamed to `updateSequenceId`. Its type has been changed from timestamp to integer.
   - Note: this is not considered a breaking change as the CLI args are still in flux. After the 1.0 release arg changes will be considered breaking.
 
 ### Fixed
+
 - Upserting repos no longer fails on non-existent repos
 
 ## [0.0.1] - 2018-12-14
+
 ### Added
+
 - Automated release pipeline for github releases and docker images
 - Changelog

--- a/README.md
+++ b/README.md
@@ -8,14 +8,13 @@ This repository provides solutions for configuring [LaunchDarkly code references
 
 We provide turnkey support for common trigger mechanisms and CI / CD providers. You can also invoke the ld-find-code-refs utility from the command line, which can be run in any custom workflow you define (e.g. from a bash script, or a cron job).
 
-| System | Status |
-|---------------------|---------------------------------------------------------------------------------------------------------|
-| GitHub Actions | [Supported](https://docs.launchdarkly.com/v2.0/docs/github-actions) |
-| CircleCI Orbs | [Supported](https://docs.launchdarkly.com/v2.0/docs/circleci-orbs) |
-| BitBucket Pipelines | [Supported](https://docs.launchdarkly.com/v2.0/docs/bitbucket-pipelines-coderefs)
-| Manually via CLI | [Supported](https://docs.launchdarkly.com/v2.0/docs/custom-configuration-via-cli) |
-| AWS Lambda jobs | Planned |
-
+| System              | Status                                                                            |
+| ------------------- | --------------------------------------------------------------------------------- |
+| GitHub Actions      | [Supported](https://docs.launchdarkly.com/v2.0/docs/github-actions)               |
+| CircleCI Orbs       | [Supported](https://docs.launchdarkly.com/v2.0/docs/circleci-orbs)                |
+| BitBucket Pipelines | [Supported](https://docs.launchdarkly.com/v2.0/docs/bitbucket-pipelines-coderefs) |
+| Manually via CLI    | [Supported](https://docs.launchdarkly.com/v2.0/docs/custom-configuration-via-cli) |
+| AWS Lambda jobs     | Planned                                                                           |
 
 ## Execution via CLI
 
@@ -33,9 +32,11 @@ brew install ld-find-code-refs
 You can now run `ld-find-code-refs`.
 
 #### Linux
-We do not yet have repositories set up for our linux packages, but we do upload deb and rpm packages with our github releases.
+
+We do not yet have repositories set up for our linux packages, but we do upload deb and rpm packages with our [github releases](https://github.com/launchdarkly/ld-find-code-refs/releases/latest).
 
 ##### Ubuntu
+
 This shell script can be used to download and install `ag` and `ld-find-code-refs` on Ubuntu.
 
 ```shell
@@ -51,10 +52,17 @@ dpkg -i ld-find-code-refs.amd64.deb
 ```
 
 ### Windows
-A Windows executable of `ld-find-code-refs` is not currently available. If you'd like to test `ld-find-code-refs` on a Windows machine, we recommend using the [docker image](https://github.com/launchdarkly/ld-find-code-refs#docker). Windows 10 users may use the [Ubuntu subsystem for Windows](https://docs.microsoft.com/en-us/windows/wsl/install-win10) as a stopgap.
+
+A Windows executable of `ld-find-code-refs` is available on the [releases page](https://github.com/launchdarkly/ld-find-code-refs/releases/latest). The following Chocolatey command may be used to install the required dependency, `ag`. If you do not have Chocolatey installed, see `ag`'s documentation for [installation instructions](https://github.com/ggreer/the_silver_searcher#windows).
+
+```powershell
+choco install ag
+```
 
 ### Docker
+
 `ld-find-code-refs` is available as a [docker image](https://hub.docker.com/r/launchdarkly/ld-find-code-refs). The command line program is installed in the system path of this docker image.
+
 <!-- TODO: update with entrypoint execution when available -->
 
 ```shell
@@ -122,35 +130,36 @@ ld-find-code-refs \
 
 A number of command-line arguments are available to the code ref finder, some optional, and some required. Command line arguments may be passed to the program in any order.
 
-| Option | Description |
-|-|-|
+| Option        | Description                                                                                                                                                                                                                                    |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `accessToken` | LaunchDarkly [personal access token](https://docs.launchdarkly.com/docs/api-access-tokens) with writer-level access, or access to the `code-reference-repository` [custom role](https://docs.launchdarkly.com/v2.0/docs/custom-roles) resource |
-| `dir` | Path to existing checkout of the git repo. The currently checked out branch will be scanned for code references. |
-| `projKey` | A LaunchDarkly project key. |
-| `repoName` | Git repo name. Will be displayed in LaunchDarkly. Repo names must only contain letters, numbers, '.', '_' or '-'." |
+| `dir`         | Path to existing checkout of the git repo. The currently checked out branch will be scanned for code references.                                                                                                                               |
+| `projKey`     | A LaunchDarkly project key.                                                                                                                                                                                                                    |
+| `repoName`    | Git repo name. Will be displayed in LaunchDarkly. Repo names must only contain letters, numbers, '.', '\_' or '-'."                                                                                                                            |
 
 ### Optional arguments
 
-Although these arguments are optional, a (*) indicates a recommended parameter that adds great value if configured.
+Although these arguments are optional, a (\*) indicates a recommended parameter that adds great value if configured.
 
-| Option | Description | Default |
-|-|-|-|
-| `baseUri` | Set the base URL of the LaunchDarkly server for this configuration. Only necessary if using a private instance of LaunchDarkly. | `https://app.launchdarkly.com` |
-| `contextLines` (*) | The number of context lines to send to LaunchDarkly. If < 0, no source code will be sent to LaunchDarkly. If 0, only the line containing flag references will be sent. If > 0, will send that number of context lines above and below the flag reference. A maximum of 5 context lines may be provided. | `2` |
-| `debug` | Enables verbose debug logging. | `false` |
-| `defaultBranch` | The git default branch. The LaunchDarkly UI will default to display code references for this branch. | `master` |
-| `exclude` (*) | A regular expression (PCRE) defining the files and directories which the flag finder should exclude. Partial matches are allowed. Examples: `vendor/`, `\.css`, `vendor/\|\.css` | |
-| `updateSequenceId` | An integer representing the order number of code reference updates. Used to version updates across concurrent executions of the program. If not provided, data will always be updated. If provided, data will only be updated if the existing `updateSequenceId` is less than the new `updateSequenceId`. Examples: the time a `git push` was initiated, CI build number, the current unix timestamp. | |
-| `repoType` (*) | The repo service provider. Used to generate repository links in the LaunchDarkly UI. Acceptable values: github\|bitbucket\|custom | `custom` |
-| `repoUrl` (*) | The display url for the repository. If provided for a github or bitbucket repository, LaunchDarkly will attempt to automatically generate source code links. Example: `https://github.com/launchdarkly/ld-find-code-refs` | |
-| `commitUrlTemplate` | If provided, LaunchDarkly will attempt to generate links to your Git service provider per commit. Example: `https://github.com/launchdarkly/ld-find-code-refs/commit/${sha}`. Allowed template variables: `branchName`, `sha`. If `commitUrlTemplate` is not provided, but `repoUrl` is provided and `repoType` is not custom, LaunchDarkly will automatically generate links to the repository for each commit. | |
-| `hunkUrlTemplate` | If provided, LaunchDarkly will attempt to generate links to your Git service provider per code reference. Example: `https://github.com/launchdarkly/ld-find-code-refs/blob/${sha}/${filePath}#L${lineNumber}`. Allowed template variables: `sha`, `filePath`, `lineNumber`. If `hunkUrlTemplate` is not provided, but `repoUrl` is provided and `repoType` is not custom, LaunchDarkly will automatically generate links to the repository for each code reference.  | |
+| Option              | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                         | Default                        |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
+| `baseUri`           | Set the base URL of the LaunchDarkly server for this configuration. Only necessary if using a private instance of LaunchDarkly.                                                                                                                                                                                                                                                                                                                                     | `https://app.launchdarkly.com` |
+| `contextLines` (\*) | The number of context lines to send to LaunchDarkly. If < 0, no source code will be sent to LaunchDarkly. If 0, only the line containing flag references will be sent. If > 0, will send that number of context lines above and below the flag reference. A maximum of 5 context lines may be provided.                                                                                                                                                             | `2`                            |
+| `debug`             | Enables verbose debug logging.                                                                                                                                                                                                                                                                                                                                                                                                                                      | `false`                        |
+| `defaultBranch`     | The git default branch. The LaunchDarkly UI will default to display code references for this branch.                                                                                                                                                                                                                                                                                                                                                                | `master`                       |
+| `exclude` (\*)      | A regular expression (PCRE) defining the files and directories which the flag finder should exclude. Partial matches are allowed. Examples: `vendor/`, `\.css`, `vendor/\|\.css`                                                                                                                                                                                                                                                                                    |                                |
+| `updateSequenceId`  | An integer representing the order number of code reference updates. Used to version updates across concurrent executions of the program. If not provided, data will always be updated. If provided, data will only be updated if the existing `updateSequenceId` is less than the new `updateSequenceId`. Examples: the time a `git push` was initiated, CI build number, the current unix timestamp.                                                               |                                |
+| `repoType` (\*)     | The repo service provider. Used to generate repository links in the LaunchDarkly UI. Acceptable values: github\|bitbucket\|custom                                                                                                                                                                                                                                                                                                                                   | `custom`                       |
+| `repoUrl` (\*)      | The display url for the repository. If provided for a github or bitbucket repository, LaunchDarkly will attempt to automatically generate source code links. Example: `https://github.com/launchdarkly/ld-find-code-refs`                                                                                                                                                                                                                                           |                                |
+| `commitUrlTemplate` | If provided, LaunchDarkly will attempt to generate links to your Git service provider per commit. Example: `https://github.com/launchdarkly/ld-find-code-refs/commit/${sha}`. Allowed template variables: `branchName`, `sha`. If `commitUrlTemplate` is not provided, but `repoUrl` is provided and `repoType` is not custom, LaunchDarkly will automatically generate links to the repository for each commit.                                                    |                                |
+| `hunkUrlTemplate`   | If provided, LaunchDarkly will attempt to generate links to your Git service provider per code reference. Example: `https://github.com/launchdarkly/ld-find-code-refs/blob/${sha}/${filePath}#L${lineNumber}`. Allowed template variables: `sha`, `filePath`, `lineNumber`. If `hunkUrlTemplate` is not provided, but `repoUrl` is provided and `repoType` is not custom, LaunchDarkly will automatically generate links to the repository for each code reference. |                                |
 
 ### Ignoring files and directories
 
 `ld-find-code-refs` provides multiple methods for ignoring files and directories:
 
-1. Provide a `.ldignore` file in the root directory of your Git repository. All patterns specified in `.ldignore` file will be excluded by the scanner. Patterns must follow the `.gitignore` format as specified here: https://git-scm.com/docs/gitignore#_pattern_format
-2. The `exclude` command line option (see above section) may be used to specify a single regular expression for the exclude pattern.
+1. All dotfiles and patterns in `.gitignore` will be excluded by default.
+2. Provide a `.ldignore` file in the root directory of your Git repository. All patterns specified in `.ldignore` file will be excluded by the scanner. Patterns must follow the `.gitignore` format as specified here: https://git-scm.com/docs/gitignore#_pattern_format
+3. The `exclude` command line option (see above section) may be used to specify a single regular expression for the exclude pattern.
 
 If both `.ldignore` and the `exclude` argument are provided, `ld-find-code-refs` will test against both for file exclusion. Do note that `.ldignore` expects shell glob patterns, while the `exclude` option expects a PCRE-compliant regular expression.

--- a/internal/command/windows.go
+++ b/internal/command/windows.go
@@ -1,0 +1,75 @@
+package command
+
+import "bytes"
+
+// Converts ANSI to UTF8: https://stackoverflow.com/a/12409923
+func fromWindows1252(str string) string {
+	var arr = []byte(str)
+	var buf bytes.Buffer
+	var r rune
+
+	for _, b := range arr {
+		switch b {
+		case 0x80:
+			r = 0x20AC
+		case 0x82:
+			r = 0x201A
+		case 0x83:
+			r = 0x0192
+		case 0x84:
+			r = 0x201E
+		case 0x85:
+			r = 0x2026
+		case 0x86:
+			r = 0x2020
+		case 0x87:
+			r = 0x2021
+		case 0x88:
+			r = 0x02C6
+		case 0x89:
+			r = 0x2030
+		case 0x8A:
+			r = 0x0160
+		case 0x8B:
+			r = 0x2039
+		case 0x8C:
+			r = 0x0152
+		case 0x8E:
+			r = 0x017D
+		case 0x91:
+			r = 0x2018
+		case 0x92:
+			r = 0x2019
+		case 0x93:
+			r = 0x201C
+		case 0x94:
+			r = 0x201D
+		case 0x95:
+			r = 0x2022
+		case 0x96:
+			r = 0x2013
+		case 0x97:
+			r = 0x2014
+		case 0x98:
+			r = 0x02DC
+		case 0x99:
+			r = 0x2122
+		case 0x9A:
+			r = 0x0161
+		case 0x9B:
+			r = 0x203A
+		case 0x9C:
+			r = 0x0153
+		case 0x9E:
+			r = 0x017E
+		case 0x9F:
+			r = 0x0178
+		default:
+			r = rune(b)
+		}
+
+		buf.WriteRune(r)
+	}
+
+	return buf.String()
+}


### PR DESCRIPTION
- Adds support for windows by conditionally executing a slightly different `ag` command when running on `GOOS=windows`.
- Adds a windows build to `.goreleaser.yml`