### PR TITLE
Prepare 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to the ld-find-code-refs program will be documented in this 
 
 ### Changed
 
-- The command-line [docker image](https://hub.docker.com/r/launchdarkly/ld-find-code-refs) now specifies `ld-find-code-refs` as the entrypoint. The docker image may now be run as `docker run launchdarkly/ld-find-code-refs -accessToken="api-xxx"...`
+- The command-line [docker image](https://hub.docker.com/r/launchdarkly/ld-find-code-refs) now specifies `ld-find-code-refs` as the entrypoint. See our [documentation](https://github.com/launchdarkly/ld-find-code-refs#docker) for instructions on running `ld-find-code-refs` via docker.
 - `ld-find-code-refs` will now only match flag keys delimited by single-quotes, double-quotes, or backticks by default. To add more delimiters, use the `delimiters` command line option.
 
 ## [0.6.0] - 2019-02-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the ld-find-code-refs program will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
-## Master
+## [0.7.0] - 2019-02-15
 
 ### Added
 

--- a/build/package/circleci/orb.yml
+++ b/build/package/circleci/orb.yml
@@ -7,7 +7,7 @@ examples:
     usage:
       version: 2.1
       orbs:
-        launchdarkly: launchdarkly/ld-find-code-refs@0.6.0
+        launchdarkly: launchdarkly/ld-find-code-refs@0.7.0
       workflows:
         main:
           jobs:
@@ -21,7 +21,7 @@ examples:
     usage:
       version: 2.1
       orbs:
-        launchdarkly: launchdarkly/ld-find-code-refs@0.6.0
+        launchdarkly: launchdarkly/ld-find-code-refs@0.7.0
       workflows:
         main:
           jobs:
@@ -36,7 +36,7 @@ examples:
     usage:
       version: 2.1
       orbs:
-        launchdarkly: launchdarkly/ld-find-code-refs@0.6.0
+        launchdarkly: launchdarkly/ld-find-code-refs@0.7.0
       workflows:
         main:
           jobs:
@@ -52,7 +52,7 @@ examples:
     usage:
       version: 2.1
       orbs:
-        launchdarkly: launchdarkly/ld-find-code-refs@0.6.0
+        launchdarkly: launchdarkly/ld-find-code-refs@0.7.0
       workflows:
         main:
           jobs:
@@ -69,7 +69,7 @@ examples:
     usage:
       version: 2.1
       orbs:
-        launchdarkly: launchdarkly/ld-find-code-refs@0.6.0
+        launchdarkly: launchdarkly/ld-find-code-refs@0.7.0
       workflows:
         main:
           jobs:
@@ -134,7 +134,7 @@ jobs:
         type: boolean
         default: false
     docker:
-      - image: launchdarkly/ld-find-code-refs:0.6.0
+      - image: launchdarkly/ld-find-code-refs:0.7.0
         entrypoint: sh
     steps:
       - checkout:

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "0.6.0"
+const Version = "0.7.0"


### PR DESCRIPTION
## [0.7.0] - 2019-02-15

### Added

- Added support for Windows. `ld-find-code-refs` releases will now contain a windows executable.
- Added a new option `-delimiters` (`-D` for short), which may be specified multiple times to specify delimiters used to match flag keys.

### Fixed

- The `dir` command line option was marked as optional, but is actually required. `ld-find-code-refs` will now recognize this option as required.
- `ld-find-code-refs` was performing extra steps to ignore directories for files in directories matched by patterns in `.ldignore`. This ignore process has been streamlined directly into the search so files in `.ldignore` are never scanned.

### Changed

- The command-line [docker image](https://hub.docker.com/r/launchdarkly/ld-find-code-refs) now specifies `ld-find-code-refs` as the entrypoint. See our [documentation](https://github.com/launchdarkly/ld-find-code-refs#docker) for instructions on running `ld-find-code-refs` via docker.
- `ld-find-code-refs` will now only match flag keys delimited by single-quotes, double-quotes, or backticks by default. To add more delimiters, use the `delimiters` command line option.