### PR TITLE
Delete stale branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the ld-find-code-refs program will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
+## Master
+
+### Added
+
+- `ld-find-code-refs` will now remove branches no longer in the git remote from LaunchDarkly.
+
 ## [1.0.1] - 2019-03-12
 
 ### Changed

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -90,6 +90,25 @@ func (c Client) revParse(branch string) (string, error) {
 	return ret, nil
 }
 
+func (c Client) RemoteBranches() (map[string]bool, error) {
+	/* #nosec */
+	cmd := exec.Command("git", "-C", c.Workspace, "ls-remote", "--quiet", "--heads")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, errors.New(string(out))
+	}
+	rgx := regexp.MustCompile("refs/heads/(.*)")
+	results := rgx.FindAllStringSubmatch(string(out), -1)
+	log.Debug.Printf("found %d branches on remote", len(results))
+	ret := map[string]bool{}
+	for _, r := range results {
+		ret[r[1]] = true
+	}
+	// the current branch should be in the list of remote branches
+	ret[c.GitBranch] = true
+	return ret, nil
+}
+
 func (c Client) SearchForFlags(flags []string, ctxLines int, delimiters []rune) ([][]string, error) {
 	args := []string{"--nogroup", "--case-sensitive"}
 	ignoreFileName := ".ldignore"

--- a/pkg/coderefs/coderefs_test.go
+++ b/pkg/coderefs/coderefs_test.go
@@ -6,9 +6,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/launchdarkly/ld-find-code-refs/internal/ld"
+	"github.com/launchdarkly/ld-find-code-refs/internal/log"
 )
 
 // Since our hunking algorithm uses some maps, resulting slice orders are not deterministic
@@ -19,6 +21,10 @@ func (h byStartingLineNumber) Len() int      { return len(h) }
 func (h byStartingLineNumber) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
 func (h byStartingLineNumber) Less(i, j int) bool {
 	return h[i].StartingLineNumber < h[j].StartingLineNumber
+}
+
+func init() {
+	log.Init(true)
 }
 
 func Test_generateReferencesFromGrep(t *testing.T) {
@@ -907,6 +913,44 @@ func Test_truncateLine(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := truncateLine(tt.line)
 			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_calculateStaleBranches(t *testing.T) {
+	specs := []struct {
+		name           string
+		branches       []string
+		remoteBranches []string
+		expected       []string
+	}{
+		{
+			name:           "stale branch",
+			branches:       []string{"master", "another-branch"},
+			remoteBranches: []string{"master"},
+			expected:       []string{"another-branch"},
+		},
+		{
+			name:           "no stale branches",
+			branches:       []string{"master"},
+			remoteBranches: []string{"master"},
+			expected:       []string{},
+		},
+	}
+
+	for _, tt := range specs {
+		t.Run(tt.name, func(t *testing.T) {
+			// transform test args into the format expected by calculateStaleBranches
+			branchReps := make([]ld.BranchRep, 0, len(tt.branches))
+			for _, b := range tt.branches {
+				branchReps = append(branchReps, ld.BranchRep{Name: b})
+			}
+			remoteBranchMap := map[string]bool{}
+			for _, b := range tt.remoteBranches {
+				remoteBranchMap[b] = true
+			}
+
+			assert.ElementsMatch(t, tt.expected, calculateStaleBranches(branchReps, remoteBranchMap))
 		})
 	}
 }


### PR DESCRIPTION
This PR adds new functionality to `ld-find-code-refs`. The scanner will now search for "stale" branches and delete the connection to that branch from LaunchDarkly.

A branch is stale if it does not exist on the Git remote of the currently selected branch. 

If the scanner fails to find or delete stale branches, it will continue with the scan (not a fatal error)