### PR TITLE
Cs/add pagination support for mammoth repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/package/bitbucket-pipelines/ld-find-code-refs-bitbucket-pipeline
 build/package/cmd/ld-find-code-refs
 /dist/
 /bin/
+.idea/

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -130,6 +130,7 @@
     "github.com/launchdarkly/api-client-go",
     "github.com/launchdarkly/json-patch",
     "github.com/olekukonko/tablewriter",
+    "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/require",
   ]
   solver-name = "gps-cdcl"

--- a/pkg/coderefs/coderefs_test.go
+++ b/pkg/coderefs/coderefs_test.go
@@ -27,6 +27,20 @@ func init() {
 	log.Init(true)
 }
 
+func Test_sortGrepResults(t *testing.T) {
+	cats1 := grepResultLine{Path: "/dev/null/cats", LineNum: 1, LineText: "", FlagKeys: []string{"src/meow/yes/pls"}}
+	cats2 := grepResultLine{Path: "/dev/null/cats", LineNum: 2, LineText: "", FlagKeys: []string{"src/meow/feed/me"}}
+	dogs5 := grepResultLine{Path: "/dev/null/dogs", LineNum: 5, LineText: "", FlagKeys: []string{"src/woof/oh/fine"}}
+	dogs15 := grepResultLine{Path: "/dev/null/dogs", LineNum: 15, LineText: "", FlagKeys: []string{"src/woof/walk/me"}}
+
+	linesToSort := grepResultLines{dogs15, cats2, dogs5, cats1}
+	expectedResults := grepResultLines{cats1, cats2, dogs5, dogs15}
+
+	sortGrepResults(linesToSort);
+
+	assert.Exactly(t, linesToSort, expectedResults, "search order for grepLines not as expected")
+}
+
 func Test_generateReferencesFromGrep(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
This adds support for pagination as suggested in #91. We have a repo with ~ 2.4k feature flags and I ended up bumping pagination to 500 to make the job go a bit faster. Based on the conversation around sorting I tried to sort grepLines by path and then lineNum, however I'm new to Golang and not so familiar with the algorithm / not much time to spend on it so hopefully you can fix it up or let me know what to fix if it's bung.

Thanks :)