### PR TITLE
Always apply delims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the ld-find-code-refs program will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [1.2.1] - [DATE]
+
+### Fixed
+- Delimiters will now always be respected when searching for flags referenced in code. This fixes a bug causing references for certain flag keys to match against other flag keys that are substrings of the matched reference.
+
 ## [1.2.0] - 2019-08-13
 
 ### Added

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "1.2.0"
+const Version = "1.2.1"

--- a/pkg/coderefs/coderefs_test.go
+++ b/pkg/coderefs/coderefs_test.go
@@ -31,9 +31,12 @@ func delimit(s string, delim string) string {
 	return delim + s + delim
 }
 
+const (
+	testFlagKey  = "someFlag"
+	testFlagKey2 = "anotherFlag"
+)
+
 func Test_generateReferencesFromGrep(t *testing.T) {
-	testFlagKey := "someFlag"
-	testFlagKey2 := "anotherFlag"
 	testResult := []string{"", "flags.txt", ":", "12", delimit(testFlagKey, `"`)}
 	testWant := grepResultLine{Path: "flags.txt", LineNum: 12, LineText: delimit(testFlagKey, `"`), FlagKeys: []string{testFlagKey}}
 
@@ -154,12 +157,12 @@ func Test_findReferencedFlags(t *testing.T) {
 	}{
 		{
 			name: "finds a flag",
-			ref:  "line contains someFlag",
+			ref:  "line contains " + delimit(testFlagKey, `"`),
 			want: []string{"someFlag"},
 		},
 		{
 			name: "finds multiple flags",
-			ref:  "line contains someFlag and anotherFlag",
+			ref:  "line contains " + delimit(testFlagKey, `"`) + " " + delimit(testFlagKey2, `"`),
 			want: []string{"someFlag", "anotherFlag"},
 		},
 		{
@@ -170,7 +173,7 @@ func Test_findReferencedFlags(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := findReferencedFlags(tt.ref, []string{"someFlag", "anotherFlag"}, `"`)
+			got := findReferencedFlags(tt.ref, []string{testFlagKey, testFlagKey2}, `"`)
 			require.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
We currently match against delimiters when performing the coderefs search against a repository, but don't validate the delimiters later on when we pick out specific flag keys in a given line. This PR makes sure we always match against delimiters when comparing flag keys against lines.