### PR TITLE
Logging cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
+      - run: sudo apt-get update
       - run: sudo apt-get install rpm
       - run: curl -sL https://git.io/goreleaser | bash -s -- --rm-dist --skip-publish --skip-validate --release-notes <(make echo-release-notes)
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,6 @@ If both `.ldignore` and the `exclude` argument are provided, `ld-find-code-refs`
 
 ### Branch garbage collection
 
-After scanning has completed, `ld-find-code-refs` will search for and delete any stale branches. A branch is considered stale if it has references in LaunchDarkly, but no longer exists on the Git remote. As a consequence of this behavior, any code references on local branches or branches belonging only to a remote other than the default one will be removed the next time `ld-find-code-refs` is run on a different branch.
+After scanning has completed, `ld-find-code-refs` will search for and prune code reference data for stale branches. A branch is considered stale if it has references in LaunchDarkly, but no longer exists on the Git remote. As a consequence of this behavior, any code references on local branches or branches belonging only to a remote other than the default one will be removed the next time `ld-find-code-refs` is run on a different branch.
 
 This operation requires your environment to be authenticated for remote access to your repository. Branch cleanup is not currently supported when running `ld-find-code-refs` via Github actions or Bitbucket pipelines.

--- a/build/package/bitbucket-pipelines/bitbucket-pipelines.go
+++ b/build/package/bitbucket-pipelines/bitbucket-pipelines.go
@@ -14,7 +14,7 @@ func main() {
 	// init logging before checking error because we need to log the error if there is one
 	log.Init(debug)
 	if err != nil {
-		log.Fatal.Fatalf("error parsing debug option: %s", err)
+		log.Error.Fatalf("error parsing debug option: %s", err)
 	}
 
 	log.Info.Printf("setting Bitbucket Pipelines env vars")
@@ -27,7 +27,7 @@ func main() {
 	}
 	ldOptions, err := o.GetLDOptionsFromEnv()
 	if err != nil {
-		log.Fatal.Fatalf("Error setting options %s", err)
+		log.Error.Fatalf("Error setting options %s", err)
 	}
 	for k, v := range ldOptions {
 		options[k] = v
@@ -37,7 +37,7 @@ func main() {
 	for k, v := range options {
 		err := flag.Set(k, v)
 		if err != nil {
-			log.Fatal.Fatalf("error setting option %s: %s", k, err)
+			log.Error.Fatalf("error setting option %s: %s", k, err)
 		}
 	}
 	log.Info.Printf("starting repo parsing program with options:\n %+v\n", options)

--- a/build/package/github-actions/github-actions.go
+++ b/build/package/github-actions/github-actions.go
@@ -20,21 +20,21 @@ func main() {
 	// init logging before checking error because we need to log the error if there is one
 	log.Init(debug)
 	if err != nil {
-		log.Fatal.Fatalf("error parsing debug option: %s", err)
+		log.Error.Fatalf("error parsing debug option: %s", err)
 	}
 
 	log.Info.Printf("Setting GitHub action env vars")
 	ghRepo := strings.Split(os.Getenv("GITHUB_REPOSITORY"), "/")
 	if len(ghRepo) < 2 {
-		log.Fatal.Fatalf("unable to validate GitHub repository name: %s", ghRepo)
+		log.Error.Fatalf("unable to validate GitHub repository name: %s", ghRepo)
 	}
 	ghBranch, err := parseBranch(os.Getenv("GITHUB_REF"))
 	if err != nil {
-		log.Fatal.Fatalf("error parsing GITHUB_REF: %s", err)
+		log.Error.Fatalf("error parsing GITHUB_REF: %s", err)
 	}
 	event, err := parseEvent(os.Getenv("GITHUB_EVENT_PATH"))
 	if err != nil {
-		log.Fatal.Fatalf("error parsing GitHub event payload at %s: %s", os.Getenv("GITHUB_EVENT_PATH"), err)
+		log.Error.Fatalf("error parsing GitHub event payload at %s: %s", os.Getenv("GITHUB_EVENT_PATH"), err)
 	}
 
 	options := map[string]string{
@@ -48,7 +48,7 @@ func main() {
 	}
 	ldOptions, err := o.GetLDOptionsFromEnv()
 	if err != nil {
-		log.Fatal.Fatalf("Error setting options: %s", err)
+		log.Error.Fatalf("Error setting options: %s", err)
 	}
 	for k, v := range ldOptions {
 		options[k] = v
@@ -58,7 +58,7 @@ func main() {
 	for k, v := range options {
 		err := flag.Set(k, v)
 		if err != nil {
-			log.Fatal.Fatalf("could not set option %s: %s", k, err)
+			log.Error.Fatalf("could not set option %s: %s", k, err)
 		}
 	}
 	// Don't log ld access token

--- a/pkg/coderefs/coderefs.go
+++ b/pkg/coderefs/coderefs.go
@@ -177,13 +177,14 @@ func Scan() {
 		}
 	}
 
+	log.Info.Printf("attempting to prune old code reference data from LaunchDarkly")
 	remoteBranches, err := gitClient.RemoteBranches()
 	if err != nil {
-		log.Warning.Printf("unable to retrieve branch list from remote, skipping branch deletion: %s", err)
+		log.Warning.Printf("unable to retrieve branch list from remote, skipping code reference pruning: %s", err)
 	} else {
 		err = deleteStaleBranches(ldApi, repoParams.Name, remoteBranches)
 		if err != nil {
-			log.Fatal.Fatalf("failed to mark stale branches for deletion: %s", err)
+			log.Fatal.Fatalf("failed to mark old branches for code reference pruning: %s", err)
 		}
 	}
 }
@@ -196,7 +197,7 @@ func deleteStaleBranches(ldApi ld.ApiClient, repoName string, remoteBranches map
 
 	staleBranches := calculateStaleBranches(branches, remoteBranches)
 	if len(staleBranches) > 0 {
-		log.Debug.Printf("marking branches for deletion: %v", staleBranches)
+		log.Debug.Printf("marking stale branches for code reference pruning: %v", staleBranches)
 		err = ldApi.PostDeleteBranchesTask(repoName, staleBranches)
 		if err != nil {
 			return err
@@ -213,7 +214,7 @@ func calculateStaleBranches(branches []ld.BranchRep, remoteBranches map[string]b
 			staleBranches = append(staleBranches, branch.Name)
 		}
 	}
-	log.Info.Printf("found %d stale branches to be marked for deletion", len(staleBranches))
+	log.Info.Printf("found %d stale branches to be marked for code reference pruning", len(staleBranches))
 	return staleBranches
 }
 

--- a/pkg/coderefs/coderefs.go
+++ b/pkg/coderefs/coderefs.go
@@ -56,12 +56,12 @@ func Scan() {
 	dir := o.Dir.Value()
 	searchClient, err := command.NewAgClient(dir)
 	if err != nil {
-		log.Fatal.Fatalf("%s", err)
+		log.Error.Fatalf("%s", err)
 	}
 
 	gitClient, err := command.NewGitClient(dir)
 	if err != nil {
-		log.Fatal.Fatalf("%s", err)
+		log.Error.Fatalf("%s", err)
 	}
 
 	projKey := o.ProjKey.Value()
@@ -141,7 +141,7 @@ func Scan() {
 	if outDir != "" {
 		outPath, err := branchRep.WriteToCSV(outDir, projKey, repoParams.Name, gitClient.GitSha)
 		if err != nil {
-			log.Error.Fatalf("error writing code references to csv: %s", err)
+			log.Fatal.Fatalf("error writing code references to csv: %s", err)
 		}
 		log.Info.Printf("wrote code references to %s", outPath)
 	}


### PR DESCRIPTION
- Clarifies language used in logging to address the concerns brought up in #98 
- Only use the fatal logger (with support CTA message) for internal fatal errors