### PR TITLE
always convert relative repo path to absolute path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the ld-find-code-refs program will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [1.3.1] - 2019-09-24
+
+### Fixed
+
+- Fixed a regression causing no references to be found when a relative path is supplied to `dir`
+
 ## [1.3.0] - 2019-09-19
 
 ### Added

--- a/build/package/circleci/orb.yml
+++ b/build/package/circleci/orb.yml
@@ -7,7 +7,7 @@ examples:
     usage:
       version: 2.1
       orbs:
-        launchdarkly: launchdarkly/ld-find-code-refs@1.3.0
+        launchdarkly: launchdarkly/ld-find-code-refs@1.3.1
       workflows:
         main:
           jobs:
@@ -21,7 +21,7 @@ examples:
     usage:
       version: 2.1
       orbs:
-        launchdarkly: launchdarkly/ld-find-code-refs@1.3.0
+        launchdarkly: launchdarkly/ld-find-code-refs@1.3.1
       workflows:
         main:
           jobs:
@@ -36,7 +36,7 @@ examples:
     usage:
       version: 2.1
       orbs:
-        launchdarkly: launchdarkly/ld-find-code-refs@1.3.0
+        launchdarkly: launchdarkly/ld-find-code-refs@1.3.1
       workflows:
         main:
           jobs:
@@ -52,7 +52,7 @@ examples:
     usage:
       version: 2.1
       orbs:
-        launchdarkly: launchdarkly/ld-find-code-refs@1.3.0
+        launchdarkly: launchdarkly/ld-find-code-refs@1.3.1
       workflows:
         main:
           jobs:
@@ -69,7 +69,7 @@ examples:
     usage:
       version: 2.1
       orbs:
-        launchdarkly: launchdarkly/ld-find-code-refs@1.3.0
+        launchdarkly: launchdarkly/ld-find-code-refs@1.3.1
       workflows:
         main:
           jobs:
@@ -134,7 +134,7 @@ jobs:
         type: boolean
         default: false
     docker:
-      - image: launchdarkly/ld-find-code-refs:1.3.0
+      - image: launchdarkly/ld-find-code-refs:1.3.1
         entrypoint: sh
     steps:
       - checkout:

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -55,6 +55,9 @@ type AgClient struct {
 }
 
 func NewAgClient(path string) (*AgClient, error) {
+	if !filepath.IsAbs(path) {
+		log.Fatal.Fatalf("expected an absolute path but received a relative path: %s", path)
+	}
 	_, err := exec.LookPath("ag")
 	if err != nil {
 		return nil, errors.New("ag (The Silver Searcher) is a required dependency, but was not found in the system PATH")

--- a/internal/command/git.go
+++ b/internal/command/git.go
@@ -4,12 +4,12 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 
 	"github.com/launchdarkly/ld-find-code-refs/internal/log"
 	o "github.com/launchdarkly/ld-find-code-refs/internal/options"
-	"github.com/launchdarkly/ld-find-code-refs/internal/validation"
 )
 
 type GitClient struct {
@@ -19,15 +19,13 @@ type GitClient struct {
 }
 
 func NewGitClient(path string) (GitClient, error) {
-	client := GitClient{}
-
-	absPath, err := validation.NormalizeAndValidatePath(path)
-	if err != nil {
-		return client, fmt.Errorf("could not validate directory option: %s", err)
+	if !filepath.IsAbs(path) {
+		log.Fatal.Fatalf("expected an absolute path but received a relative path: %s", path)
 	}
-	client.workspace = absPath
 
-	_, err = exec.LookPath("git")
+	client := GitClient{workspace: path}
+
+	_, err := exec.LookPath("git")
 	if err != nil {
 		return client, errors.New("git is a required dependency, but was not found in the system PATH")
 	}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "1.3.0"
+const Version = "1.3.1"

--- a/pkg/coderefs/coderefs.go
+++ b/pkg/coderefs/coderefs.go
@@ -14,6 +14,7 @@ import (
 	"github.com/launchdarkly/ld-find-code-refs/internal/ld"
 	"github.com/launchdarkly/ld-find-code-refs/internal/log"
 	o "github.com/launchdarkly/ld-find-code-refs/internal/options"
+	"github.com/launchdarkly/ld-find-code-refs/internal/validation"
 	"github.com/launchdarkly/ld-find-code-refs/internal/version"
 )
 
@@ -54,12 +55,18 @@ type branch struct {
 
 func Scan() {
 	dir := o.Dir.Value()
-	searchClient, err := command.NewAgClient(dir)
+	absPath, err := validation.NormalizeAndValidatePath(dir)
+	if err != nil {
+		log.Error.Fatalf("could not validate directory option: %s", err)
+	}
+
+	log.Info.Printf("absolute directory path: %s", absPath)
+	searchClient, err := command.NewAgClient(absPath)
 	if err != nil {
 		log.Error.Fatalf("%s", err)
 	}
 
-	gitClient, err := command.NewGitClient(dir)
+	gitClient, err := command.NewGitClient(absPath)
 	if err != nil {
 		log.Error.Fatalf("%s", err)
 	}


### PR DESCRIPTION
## [1.3.1] - 2019-09-24

### Fixed

- Fixed a regression causing no references to be found when a relative path is supplied to `dir`