### PR TITLE
prepare 1.5.0-beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the ld-find-code-refs program will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [1.5.0] - prerelease
+
+### Added
+
+- Added the ability to configure flag alias detection using a YAML configuration. See [https://github.com/launchdarkly/ld-find-code-refs#configuring-aliases](the README) for instructions.
+
+### Fixed
+
+- Improved logging around limitations.
+- Fixed an edge case where false positives might be picked up for flag keys containing regular expression characters.
+
 ## [1.4.0] - 2020-03-16
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -34,20 +34,21 @@ echo-release-notes:
 
 define publish_docker
 	test $(1) || (echo "Please provide tag"; exit 1)
-	docker build -t launchdarkly/$(2):$(1) build/package/$(3)
-	docker tag launchdarkly/$(2):$(1) launchdarkly/$(2):latest
-	docker push launchdarkly/$(2):$(1)
-	docker push launchdarkly/$(2):latest
+	docker build -t launchdarkly/$(3):$(1) build/package/$(4)
+	docker push launchdarkly/$(3):$(1)
+	test $(2) && (echo "Not pushing latest tag for prerelease"; exit 1)
+	docker tag launchdarkly/$(3):$(1) launchdarkly/$(3):latest
+	docker push launchdarkly/$(3):latest
 endef
 
 publish-cli-docker: compile-linux-binary
-	$(call publish_docker,$(TAG),ld-find-code-refs,cmd)
+	$(call publish_docker,$(TAG),$(PRERELEASE),ld-find-code-refs,cmd)
 
 publish-github-actions-docker: compile-github-actions-binary
-	$(call publish_docker,$(TAG),ld-find-code-refs-github-action,github-actions)
+	$(call publish_docker,$(TAG),$(PRERELEASE),ld-find-code-refs-github-action,github-actions)
 
 publish-bitbucket-pipelines-docker: compile-bitbucket-pipelines-binary
-	$(call publish_docker,$(TAG),ld-find-code-refs-bitbucket-pipeline,bitbucket-pipelines)
+	$(call publish_docker,$(TAG),$(PRERELEASE),ld-find-code-refs-bitbucket-pipeline,bitbucket-pipelines)
 
 validate-circle-orb:
 	test $(TAG) || (echo "Please provide tag"; exit 1)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -20,3 +20,7 @@ To push a new image version to Docker hub, run `make publish-cli-docker TAG=$VER
 To publish the CircleCI Orb to the Orb registry, you'll need the [CircleCI CLI](https://circleci.com/docs/2.0/local-cli/) installed, and will need to run `circleci setup` and authenticate with a circle token that has github owner status.
 
 Run `make publish-dev-circle-orb TAG=$VERSION` or `make-publish-release-circle-orb TAG=$VERSION` to publish the orb to the orb registry, where `$VERSION` is the version you want to release. Running `publish-dev-circle-orb` will publish a development-tagged (e.g. `dev:0.0.1`) orb, which can be overwritten, and `publish-release-circle-orb` will publish a release version of the orb, which is immutable. Both dev and release orbs are open to the public, but development orbs are not visible in the list of registered orbs on Circle's [website](https://circleci.com/orbs/registry/?showAll=true).
+
+## Beta builds
+
+To push a beta build, set the `PRERELEASE=true` environment variable before running a release task. e.g. `make publish-all TAG=1.0.0-beta1`.


### PR DESCRIPTION
- Adds 1.5.0 entry to the changelog (link will 404 until https://github.com/launchdarkly/ld-find-code-refs/pull/110) is merged
- Adds a new env variable for releasing prerelease builds