### PR TITLE
alias fixes for command line wrappers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,9 +36,9 @@ define publish_docker
 	test $(1) || (echo "Please provide tag"; exit 1)
 	docker build -t launchdarkly/$(3):$(1) build/package/$(4)
 	docker push launchdarkly/$(3):$(1)
-	test $(2) && (echo "Not pushing latest tag for prerelease"; exit 1)
-	docker tag launchdarkly/$(3):$(1) launchdarkly/$(3):latest
-	docker push launchdarkly/$(3):latest
+	test $(2) && (echo "Not pushing latest tag for prerelease")
+	test $(2) || docker tag launchdarkly/$(3):$(1) launchdarkly/$(3):latest
+	test $(2) || docker push launchdarkly/$(3):latest
 endef
 
 publish-cli-docker: compile-linux-binary

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -23,4 +23,4 @@ Run `make publish-dev-circle-orb TAG=$VERSION` or `make-publish-release-circle-o
 
 ## Beta builds
 
-To push a beta build, set the `PRERELEASE=true` environment variable before running a release task. e.g. `make publish-all TAG=1.0.0-beta1`.
+To push a beta build, set the `PRERELEASE=true` environment variable before running a release task. e.g. `make publish-all TAG=1.0.0-beta1`. Note: to publish a beta circle ci orb, run `make publish-dev-circle-orb TAG=$VERSION`

--- a/build/package/bitbucket-pipelines/bitbucket-pipelines.go
+++ b/build/package/bitbucket-pipelines/bitbucket-pipelines.go
@@ -33,7 +33,10 @@ func main() {
 		options[k] = v
 	}
 
-	o.Populate()
+	err = o.Populate()
+	if err != nil {
+		log.Error.Fatalf("could not set options: %v", err)
+	}
 	for k, v := range options {
 		err := flag.Set(k, v)
 		if err != nil {

--- a/build/package/github-actions/github-actions.go
+++ b/build/package/github-actions/github-actions.go
@@ -54,7 +54,10 @@ func main() {
 		options[k] = v
 	}
 
-	o.Populate()
+	err = o.Populate()
+	if err != nil {
+		log.Error.Fatalf("could not set options: %v", err)
+	}
 	for k, v := range options {
 		err := flag.Set(k, v)
 		if err != nil {

--- a/internal/options/options.go
+++ b/internal/options/options.go
@@ -176,7 +176,10 @@ var options = optionMap{
 // Returns an error if a required option has not been set, or if an option is invalid.
 func Init() (err error, errCb func()) {
 	if !populated {
-		Populate()
+		err = Populate()
+		if err != nil {
+			return err, nil
+		}
 	}
 
 	flag.Parse()
@@ -244,21 +247,15 @@ func Init() (err error, errCb func()) {
 		}
 	}
 
-	yamlOptions, err := Yaml()
-	if err != nil {
-		return err, nil
-	}
-	if yamlOptions != nil {
-		Aliases = yamlOptions.Aliases
-	}
-
 	return nil, flag.PrintDefaults
 }
 
 var populated = false
 
-func Populate() {
+func Populate() error {
+
 	populated = true
+
 	for n, o := range options {
 		name := n.name()
 		switch v := o.defaultValue.(type) {
@@ -274,6 +271,16 @@ func Populate() {
 			flag.Var(v, name, o.usage)
 		}
 	}
+
+	yamlOptions, err := Yaml()
+	if err != nil {
+		return err
+	}
+	if yamlOptions != nil {
+		Aliases = yamlOptions.Aliases
+	}
+
+	return nil
 }
 
 // GetLDOptionsFromEnv returns a map of all expected environment variables for ld-find-code-refs wrappers


### PR DESCRIPTION
Fixes the release job to make sure we release to all destinations when running `publish-all`
Makes sure all wrappers support aliases

This code is already including with the 1.5.0-beta1 release.