### PR TITLE
support glob patterns for filePattern alias matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,14 +243,17 @@ aliases:
 
 #### Search a file for a specific pattern
 
-Specify a file to search, with a regular expression containing a capture group to match aliases. The pattern must contain the templated literal `FLAG_KEY` to be replaced with flag keys.
+Specify a number of files (`paths`) using [glob patterns](https://en.wikipedia.org/wiki/Glob_(programming)) to search. Be as specific as possible with your path globs to minimize the number of files searched for aliases.
 
-Example matching all variable names storing flag keys of the form `MyFlagKey := "my-flag"` in the file `test.go`:
+You must also specify a regular expression (`pattern`) containing a capture group to match aliases. The pattern must contain the the text `FLAG_KEY`, which will be subsituted with flag keys.
+
+Example matching all variable names storing flag keys of the form `MyFlagKey := "my-flag"` in .go files do not end with `_test`:
 
 ```yaml
 aliases:
   - type: filePattern
-    path: test.go
+    paths:
+      - '*[!_test].go'
     pattern: (\w+Key) := "FLAG_KEY"
 ```
 

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -1,0 +1,13 @@
+package helpers
+
+func Dedupe(s []string) []string {
+	keys := make(map[string]struct{}, len(s))
+	ret := make([]string, 0, len(s))
+	for _, entry := range s {
+		if _, value := keys[entry]; !value {
+			keys[entry] = struct{}{}
+			ret = append(ret, entry)
+		}
+	}
+	return ret
+}

--- a/pkg/coderefs/alias.go
+++ b/pkg/coderefs/alias.go
@@ -1,6 +1,7 @@
 package coderefs
 
 import (
+	"github.com/launchdarkly/ld-find-code-refs/internal/helpers"
 	"github.com/launchdarkly/ld-find-code-refs/internal/options"
 )
 
@@ -14,19 +15,7 @@ func generateAliases(flags []string, aliases []options.Alias) (map[string][]stri
 			}
 			ret[flag] = append(ret[flag], flagAliases...)
 		}
-		ret[flag] = dedupe(ret[flag])
+		ret[flag] = helpers.Dedupe(ret[flag])
 	}
 	return ret, nil
-}
-
-func dedupe(s []string) []string {
-	keys := make(map[string]struct{}, len(s))
-	ret := make([]string, 0, len(s))
-	for _, entry := range s {
-		if _, value := keys[entry]; !value {
-			keys[entry] = struct{}{}
-			ret = append(ret, entry)
-		}
-	}
-	return ret
 }

--- a/pkg/coderefs/alias_test.go
+++ b/pkg/coderefs/alias_test.go
@@ -113,7 +113,7 @@ func filePattern(flag string) o.Alias {
 	a := alias(o.FilePattern)
 	pattern := "(\\w+)\\s= 'FLAG_KEY'"
 	a.Pattern = &pattern
-	a.FileContents = []byte(fmt.Sprintf("SOME_FLAG = '%s'", flag))
+	a.AllFileContents = []byte(fmt.Sprintf("SOME_FLAG = '%s'", flag))
 	return a
 }
 

--- a/pkg/coderefs/coderefs.go
+++ b/pkg/coderefs/coderefs.go
@@ -11,9 +11,9 @@ import (
 	"time"
 
 	"github.com/launchdarkly/ld-find-code-refs/internal/command"
+	"github.com/launchdarkly/ld-find-code-refs/internal/helpers"
 	"github.com/launchdarkly/ld-find-code-refs/internal/ld"
 	"github.com/launchdarkly/ld-find-code-refs/internal/log"
-	"github.com/launchdarkly/ld-find-code-refs/internal/options"
 	o "github.com/launchdarkly/ld-find-code-refs/internal/options"
 	"github.com/launchdarkly/ld-find-code-refs/internal/validation"
 	"github.com/launchdarkly/ld-find-code-refs/internal/version"
@@ -121,7 +121,7 @@ func Scan() {
 		log.Warning.Printf("omitting %d flags with keys less than minimum (%d)", len(omittedFlags), minFlagKeyLen)
 	}
 
-	aliases, err := generateAliases(filteredFlags, options.Aliases)
+	aliases, err := generateAliases(filteredFlags, o.Aliases)
 	if err != nil {
 		log.Error.Fatalf("failed to create flag key aliases: %v", err)
 	}
@@ -497,7 +497,7 @@ func buildHunksForFlag(projKey, flag, path string, flagReferences []*list.Elemen
 			appendToPreviousHunk = false
 		} else {
 			currentHunk.Lines = hunkStringBuilder.String()
-			currentHunk.Aliases = dedupe(currentHunk.Aliases)
+			currentHunk.Aliases = helpers.Dedupe(currentHunk.Aliases)
 			hunks = append(hunks, currentHunk)
 			previousHunk = &hunks[len(hunks)-1]
 		}


### PR DESCRIPTION
Replaces the `path` options with `paths`, an array of globs. This allows for more succinct declaration of alias search.