### PR TITLE
rename coderefs.yaml to config.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Although these arguments are optional, a (\*) indicates a recommended parameter 
 
 ### Configuring aliases
 
-Flag key aliases may be defined using a YAML file stored in your repository at `.launchdarkly/config.yaml`. Configuration types may be used in conjunction and defined more than once for comprehensive alias coverage.
+Flag key aliases may be defined using a YAML file stored in your repository at `.launchdarkly/coderefs.yaml`. Configuration types may be used in conjunction and defined more than once for comprehensive alias coverage.
 
 
 #### Hardcoded map of flag keys to aliases

--- a/internal/options/alias.go
+++ b/internal/options/alias.go
@@ -201,9 +201,12 @@ func (o *YamlOptions) IsValid() error {
 }
 
 func Yaml() (*YamlOptions, error) {
-	pathToYaml := filepath.Join(Dir.Value(), ".launchdarkly/config.yaml")
+	pathToYaml := filepath.Join(Dir.Value(), ".launchdarkly/coderefs.yaml")
 	if !validation.FileExists(pathToYaml) {
-		return nil, nil
+		pathToYaml = filepath.Join(Dir.Value(), ".launchdarkly/coderefs.yml")
+		if !validation.FileExists(pathToYaml) {
+			return nil, nil
+		}
 	}
 
 	/* #nosec */


### PR DESCRIPTION
This frees up the `.launchdarkly` directory namespace for potential future usage.