### PR TITLE
check for yaml configuration when initializing cli options

### DIFF
--- a/internal/options/options.go
+++ b/internal/options/options.go
@@ -247,6 +247,14 @@ func Init() (err error, errCb func()) {
 		}
 	}
 
+	yamlOptions, err := Yaml()
+	if err != nil {
+		return nil, nil
+	}
+	if yamlOptions != nil {
+		Aliases = yamlOptions.Aliases
+	}
+
 	return nil, flag.PrintDefaults
 }
 

--- a/internal/options/options.go
+++ b/internal/options/options.go
@@ -249,7 +249,7 @@ func Init() (err error, errCb func()) {
 
 	yamlOptions, err := Yaml()
 	if err != nil {
-		return nil, nil
+		return err, nil
 	}
 	if yamlOptions != nil {
 		Aliases = yamlOptions.Aliases


### PR DESCRIPTION
My last change in https://github.com/launchdarkly/ld-find-code-refs/pull/112 inadvertently broke configuration via CLI. For now, let's duplicate the yaml read logic in both `Init` and `Populate`-- moving the configuration format to viper later on will make this code easier to read and less prone to error.