### PR TITLE
Make alias config type field case insensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,10 +228,10 @@ Aliases can be generated using any of the following common naming conventions. F
 
 Example flag key: `AnyKind.of_key`
 
-| Type             | After      |
-|------------------|------------|
-| `camelcase`      | `anyKind.ofKey`  |
-| `pascalcase`     | `AnyKind.OfKey`  |
+| Type             | After             |
+|------------------|-------------------|
+| `camelcase`      | `anyKind.ofKey`   |
+| `pascalcase`     | `AnyKind.OfKey`   |
 | `snakecase`      | `any_kind.of_key` |
 | `uppersnakecase` | `ANY_KIND.OF_KEY` |
 | `kebabcase`      | `any-kind.of-key` |

--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ Flag key aliases may be defined using a YAML file stored in your repository at `
 
 #### Hardcoded map of flag keys to aliases
 
+Aliases can be hardcoded using the `literal` type. This is intended to be used for testing aliasing functionality.
+
 Example hardcoding aliases for a couple flags:
 
 ```yaml
@@ -221,6 +223,8 @@ aliases:
 ```
 
 #### Flag keys transposed to common casing conventions
+
+Aliases can be generated using any of the following common naming conventions. For more robust patterns, see the other available options below this section.
 
 Example flag key: `AnyKind.of_key`
 

--- a/README.md
+++ b/README.md
@@ -226,47 +226,47 @@ Example flag key: `AnyKind.of_key`
 
 | Type             | After      |
 |------------------|------------|
-| `camelCase`      | `anyKind.ofKey`  |
-| `pascalCase`     | `AnyKind.OfKey`  |
-| `snakeCase`      | `any_kind.of_key` |
-| `upperSnakeCase` | `ANY_KIND.OF_KEY` |
-| `kebabCase`      | `any-kind.of-key` |
-| `dotCase`        | `any.kind.of.key` |
+| `camelcase`      | `anyKind.ofKey`  |
+| `pascalcase`     | `AnyKind.OfKey`  |
+| `snakecase`      | `any_kind.of_key` |
+| `uppersnakecase` | `ANY_KIND.OF_KEY` |
+| `kebabcase`      | `any-kind.of-key` |
+| `dotcase`        | `any.kind.of.key` |
 
 Example generating aliases in camelCase and PascalCase:
 
 ```yaml
 aliases:
-  - type: camelCase
-  - type: pascalCase
+  - type: camelcase
+  - type: pascalcase
 ```
 
-#### Search a file for a specific pattern
+#### Search files for a specific pattern
 
-Specify a number of files (`paths`) using [glob patterns](https://en.wikipedia.org/wiki/Glob_(programming)) to search. Be as specific as possible with your path globs to minimize the number of files searched for aliases.
+You can specify a number of files (`paths`) using [glob patterns](https://en.wikipedia.org/wiki/Glob_(programming)) to search. Be as specific as possible with your path globs to minimize the number of files searched for aliases.
 
-You must also specify a regular expression (`pattern`) containing a capture group to match aliases. The pattern must contain the the text `FLAG_KEY`, which will be subsituted with flag keys.
+You must also specify a regular expression (`pattern`) containing a capture group to match aliases. The pattern must contain the the text `FLAG_KEY`, which will be interpolated with flag keys.
 
-Example matching all variable names storing flag keys of the form `MyFlagKey := "my-flag"` in .go files do not end with `_test`:
+Example matching all variable names storing flag keys of the form `var ENABLE_WIDGETS = "enable-widgets"` in .go files do not end with `_test`:
 
 ```yaml
 aliases:
-  - type: filePattern
+  - type: filepattern
     paths:
       - '*[!_test].go'
-    pattern: (\w+Key) := "FLAG_KEY"
+    pattern: '(\w+) = "FLAG_KEY"'
 ```
 
 #### Execute a command script
 
-Any command may be executed to generate aliases. The command will receive a flag key as standard input. `ld-find-code-refs` expects a valid JSON array of flag keys output to stdout.
+For more control over your aliases, you can write a script to generate aliases. The script will receive a flag key as standard input. `ld-find-code-refs` expects a valid JSON array of flag keys output to stdout.
 
 Here's an example of a bash script which returns the the flag key as it's own alias:
 
 ```yaml
 aliases:
   - type: command
-    command: .launchdarkly/launchdarklyAlias.sh
+    command: .launchdarkly/launchdarklyAlias.sh # must be a valid shell command.
     timeout: 5 # seconds
 ```
 

--- a/internal/options/alias.go
+++ b/internal/options/alias.go
@@ -26,20 +26,28 @@ import (
 type AliasType string
 
 func (a AliasType) IsValid() error {
-	switch a {
+	switch a.canonical() {
 	case Literal, CamelCase, PascalCase, SnakeCase, UpperSnakeCase, KebabCase, DotCase, FilePattern, Command:
 		return nil
 	}
 	return fmt.Errorf("'%s' is not a valid alias type", a)
 }
 
-func (t AliasType) unexpectedFieldErr(field string) error {
-	return fmt.Errorf("unexpected field for %s alias: '%s'", t, field)
+func (a AliasType) String() string {
+	return strings.ToLower(string(a))
+}
+
+func (a AliasType) canonical() AliasType {
+	return AliasType(a.String())
+}
+
+func (a AliasType) unexpectedFieldErr(field string) error {
+	return fmt.Errorf("unexpected field for %s alias: '%s'", a, field)
 }
 
 func (a Alias) Generate(flag string) ([]string, error) {
 	ret := []string{}
-	switch AliasType(strings.ToLower(string(a.Type))) {
+	switch a.Type.canonical() {
 	case Literal:
 		ret = a.Flags[flag]
 	case CamelCase:

--- a/internal/options/alias.go
+++ b/internal/options/alias.go
@@ -39,7 +39,7 @@ func (t AliasType) unexpectedFieldErr(field string) error {
 
 func (a Alias) Generate(flag string) ([]string, error) {
 	ret := []string{}
-	switch a.Type {
+	switch AliasType(strings.ToLower(string(a.Type))) {
 	case Literal:
 		ret = a.Flags[flag]
 	case CamelCase:
@@ -95,14 +95,14 @@ func (a Alias) Generate(flag string) ([]string, error) {
 const (
 	Literal AliasType = "literal"
 
-	CamelCase      AliasType = "camelCase"
-	PascalCase     AliasType = "pascalCase"
-	SnakeCase      AliasType = "snakeCase"
-	UpperSnakeCase AliasType = "upperSnakeCase"
-	KebabCase      AliasType = "kebabCase"
-	DotCase        AliasType = "dotCase"
+	CamelCase      AliasType = "camelcase"
+	PascalCase     AliasType = "pascalcase"
+	SnakeCase      AliasType = "snakecase"
+	UpperSnakeCase AliasType = "uppersnakecase"
+	KebabCase      AliasType = "kebabcase"
+	DotCase        AliasType = "dotcase"
 
-	FilePattern AliasType = "filePattern"
+	FilePattern AliasType = "filepattern"
 
 	Command AliasType = "command"
 )

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "1.5.0-beta1"
+const Version = "1.5.0-beta2"


### PR DESCRIPTION
Includes some readme improvements. Code changes do not break 1.5.0-beta2 functionality, so these changes will be included by overwriting 1.5.0-beta2.