### PR TITLE
Support specifying multiple alias patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ aliases:
 
 You can specify a number of files (`paths`) using [glob patterns](https://en.wikipedia.org/wiki/Glob_(programming)) to search. Be as specific as possible with your path globs to minimize the number of files searched for aliases.
 
-You must also specify a regular expression (`pattern`) containing a capture group to match aliases. The pattern must contain the the text `FLAG_KEY`, which will be interpolated with flag keys.
+You must also specify at least one regular expression (`pattern`) containing a capture group to match aliases. The pattern must contain the the text `FLAG_KEY`, which will be interpolated with flag keys.
 
 Example matching all variable names storing flag keys of the form `var ENABLE_WIDGETS = "enable-widgets"` in .go files do not end with `_test`:
 
@@ -258,7 +258,8 @@ aliases:
   - type: filepattern
     paths:
       - '*[!_test].go'
-    pattern: '(\w+) = "FLAG_KEY"'
+    patterns: 
+      - '(\w+) = "FLAG_KEY"'
 ```
 
 #### Execute a command script

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "1.5.0-beta2"
+const Version = "1.5.0-beta3"

--- a/pkg/coderefs/alias_test.go
+++ b/pkg/coderefs/alias_test.go
@@ -112,7 +112,7 @@ func literal(flags []string) o.Alias {
 func filePattern(flag string) o.Alias {
 	a := alias(o.FilePattern)
 	pattern := "(\\w+)\\s= 'FLAG_KEY'"
-	a.Pattern = &pattern
+	a.Patterns = []string{pattern}
 	a.AllFileContents = []byte(fmt.Sprintf("SOME_FLAG = '%s'", flag))
 	return a
 }


### PR DESCRIPTION
This PR adds support for specifying multiple patterns per filepattern configuration by specifying multiple `patterns` in a list, instead of a single `pattern`. This PR also removes the obsolete `pattern` and `path` config options.

Before:
```
aliases:
  - type: filepattern
     files: 
        - test.go
     pattern: "FLAG_KEY"
```

After:
```
aliases:
  - type: filepattern
     files: 
        - test.go
     patterns: 
        - "(FLAG_KEY)"
```