### PR TITLE
Support scanning for coderefs for non-git codebases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 out/
 .vscode
 ld-find-code-refs
+!cmd/ld-find-code-refs
 build/package/github-actions/ld-find-code-refs-github-action
 build/package/bitbucket-pipelines/ld-find-code-refs-bitbucket-pipeline
 build/package/cmd/ld-find-code-refs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to the ld-find-code-refs program will be documented in this 
   ```
 - All command line flags can now be specified as environment variables.
 - Added support for scanning non-git repositories. Use the `--revision` flag to specify your repository version number.
-- Added the `prune` sub-command to delete stale code reference data from LaunchDarkly manually by providing a list of branch names as arguments. example: `ld-find-code-refs prune [flags] branch1 branch2`
+- Added the `prune` sub-command to delete stale code reference data from LaunchDarkly manually by providing a list of branch names as arguments. example: `ld-find-code-refs prune [flags] "branch1" "branch2"`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to the ld-find-code-refs program will be documented in this 
     defaultsDisabled: true
   ```
 - All command line flags can now be specified as environment variables.
+- Added support for scanning non-git repositories. Use the `--revision` flag to specify your repository version number.
+- Added the `prune` sub-command to delete stale code reference data from LaunchDarkly manually by providing a list of branch names as arguments. example: `ld-find-code-refs prune [flags] branch1 branch2`
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ We recommend incorporating `ld-find-code-refs` into your CI/CD build process. `l
 
 ### Prerequisites
 
-`ld-find-code-refs` requires git (tested with version 2.21.0) to be installed on the system path.
+If you are scanning a git repository, `ld-find-code-refs` requires git (tested with version 2.21.0) to be installed on the system path.
 
 All turn-key configuration methods (docker images used by services like CircleCI or Github actions) come with git preinstalled.
 
@@ -84,12 +84,12 @@ A Windows executable of `ld-find-code-refs` is available on the [releases page](
 
 #### Docker
 
-`ld-find-code-refs` is available as a [docker image](https://hub.docker.com/r/launchdarkly/ld-find-code-refs). The image provides an entrypoint for `ld-find-code-refs`, to which command line arguments may be passed. If using the entrypoint, your git repository to be scanned should be mounted as a volume. Otherwise, you may override the entrypoint and access `ld-find-code-refs` directly from the shell.
+`ld-find-code-refs` is available as a [docker image](https://hub.docker.com/r/launchdarkly/ld-find-code-refs). The image provides an entrypoint for `ld-find-code-refs`, to which command line arguments may be passed. If using the entrypoint, your repository to be scanned should be mounted as a volume. Otherwise, you may override the entrypoint and access `ld-find-code-refs` directly from the shell.
 
 ```bash
 docker pull launchdarkly/ld-find-code-refs
 docker run \
-  -v /path/to/git/repo:/repo \
+  -v /path/to/your/repo:/repo \
   launchdarkly/ld-find-code-refs \
   --dir="/repo"
 ```
@@ -114,5 +114,7 @@ Configuration options include, but are not limited to:
 ### Branch garbage collection
 
 After scanning has completed, `ld-find-code-refs` will search for and prune code reference data for stale branches. A branch is considered stale if it has references in LaunchDarkly, but no longer exists on the Git remote. As a consequence of this behavior, any code references on local branches or branches belonging only to a remote other than the default one will be removed the next time `ld-find-code-refs` is run on a different branch.
+
+Stale branches may also be removed manually with the `ld-find-code-refs prune` subcommand.
 
 This operation requires your environment to be authenticated for remote access to your repository. Branch cleanup is not currently supported when running `ld-find-code-refs` with Bitbucket pipelines.

--- a/cmd/ld-find-code-refs/main.go
+++ b/cmd/ld-find-code-refs/main.go
@@ -13,7 +13,7 @@ import (
 
 var prune = &cobra.Command{
 	Use:     "prune [flags] branches...",
-	Example: "ld-find-code-refs prune branch1 branch2 # prunes branch1 and branch2",
+	Example: "ld-find-code-refs prune \"branch1\" \"branch2\" # prunes branch1 and branch2",
 	Short:   "Delete stale code reference data stored in LaunchDarkly. Accepts stale branch names as arguments",
 	Args:    cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/ld-find-code-refs/main.go
+++ b/cmd/ld-find-code-refs/main.go
@@ -11,6 +11,32 @@ import (
 	"github.com/launchdarkly/ld-find-code-refs/pkg/coderefs"
 )
 
+var prune = &cobra.Command{
+	Use:     "prune [flags] branches...",
+	Example: "ld-find-code-refs prune branch1 branch2 # prunes branch1 and branch2",
+	Short:   "Delete stale code reference data stored in LaunchDarkly. Accepts stale branch names as arguments",
+	Args:    cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		err := o.InitYAML()
+		if err != nil {
+			return err
+		}
+
+		opts, err := o.GetOptions()
+		if err != nil {
+			return err
+		}
+		err = opts.ValidateRequired()
+		if err != nil {
+			return err
+		}
+
+		log.Init(opts.Debug)
+		coderefs.Prune(opts, args)
+		return nil
+	},
+}
+
 var cmd = &cobra.Command{
 	Use: "ld-find-code-refs",
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -40,6 +66,8 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	cmd.AddCommand(prune)
+
 	err = cmd.Execute()
 	if err != nil {
 		os.Exit(1)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -61,6 +61,8 @@ Flags:
 
   -u, --repoUrl string             The display url for the repository. If provided for a github or bitbucket repository, LaunchDarkly will attempt to automatically generate source code links.
 
+  -R, --revision string            The current revision of the repository to be scanned. If set, the version string for the scanned repository will not be inferred, and branch garbage collection will be disabled. Use this option to scan non-git codebases
+
   -s, --updateSequenceId int       An integer representing the order number of code reference updates. Used to version updates across concurrent executions of the flag finder. If not provided, data will always be updated. If provided, data will only be updated if the existing "updateSequenceId" is less than the new "updateSequenceId". Examples: the time a "git push" was initiated, CI build number, the current unix timestamp. (default -1)
 ```
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -61,7 +61,7 @@ Flags:
 
   -u, --repoUrl string             The display url for the repository. If provided for a github or bitbucket repository, LaunchDarkly will attempt to automatically generate source code links.
 
-  -R, --revision string            The current revision of the repository to be scanned. If set, the version string for the scanned repository will not be inferred, and branch garbage collection will be disabled. Use this option to scan non-git codebases
+  -R, --revision string            `Use this option to scan non-git codebases. The current revision of the repository to be scanned. If set, the version string for the scanned repository will not be inferred, and branch garbage collection will be disabled. The "branch" option is required when "revision" is set.
 
   -s, --updateSequenceId int       An integer representing the order number of code reference updates. Used to version updates across concurrent executions of the flag finder. If not provided, data will always be updated. If provided, data will only be updated if the existing "updateSequenceId" is less than the new "updateSequenceId". Examples: the time a "git push" was initiated, CI build number, the current unix timestamp. (default -1)
 ```

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -48,7 +48,7 @@ ld-find-code-refs \
   --accessToken=$YOUR_LAUNCHDARKLY_ACCESS_TOKEN \ # example: api-xxxx
   --projKey=$YOUR_LAUNCHDARKLY_PROJECT_KEY \ # example: my-project
   --repoName=$YOUR_REPOSITORY_NAME \ # example: my-repo
-  --dir="/path/to/git/repo"
+  --dir="/path/to/git/repo" \
   --revision="REPO_REVISION_STRING" \ # e.g. a version hash
   --branch="dev"
 ```
@@ -63,6 +63,6 @@ ld-find-code-refs prune \
   --accessToken=$YOUR_LAUNCHDARKLY_ACCESS_TOKEN \ # example: api-xxxx
   --projKey=$YOUR_LAUNCHDARKLY_PROJECT_KEY \ # example: my-project
   --repoName=$YOUR_REPOSITORY_NAME \ # example: my-repo
-  --dir="/path/to/git/repo"
+  --dir="/path/to/git/repo" \
   "branch1" "branch2"
 ```

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -41,7 +41,7 @@ ld-find-code-refs \
 ```
 ## Scanning non-git repositories
 
-By default, `ld-find-code-refs` will attempt to infer repository metadata from a git configuration. If you are scanning codebase a version control system other than git, you may use the `--revision` and `--branch` options to manually provide information about your codebase.
+By default, `ld-find-code-refs` will attempt to infer repository metadata from a git configuration. If you are scanning a codebase with a version control system other than git, you must use the `--revision` and `--branch` options to manually provide information about your codebase.
 
 ```bash
 ld-find-code-refs \

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -39,3 +39,30 @@ ld-find-code-refs \
   --repoType="github"
   --repoUrl="$YOUR_REPOSITORY_URL" # example: https://github.com/launchdarkly/ld-find-code-refs
 ```
+## Scanning non-git repositories
+
+By default, `ld-find-code-refs` will attempt to infer repository metadata from a git configuration. If you are scanning codebase a version control system other than git, you may use the `--revision` and `--branch` options to manually provide information about your codebase.
+
+```bash
+ld-find-code-refs \
+  --accessToken=$YOUR_LAUNCHDARKLY_ACCESS_TOKEN \ # example: api-xxxx
+  --projKey=$YOUR_LAUNCHDARKLY_PROJECT_KEY \ # example: my-project
+  --repoName=$YOUR_REPOSITORY_NAME \ # example: my-repo
+  --dir="/path/to/git/repo"
+  --revision="REPO_REVISION_STRING" \ # e.g. a version hash
+  --branch="dev"
+```
+
+### Branch garbage collection for non-git repositories
+
+When scanning a non-git repository, automatic [branch garbage collection](../README.md#branch-garbage-collection) is disabled. The `prune` sub-command may be used to manually delete code references for stale branches.
+
+The following example instructs the `prune` command to delete code references for the branches named "branch1" and "branch2":
+```bash
+ld-find-code-refs prune \
+  --accessToken=$YOUR_LAUNCHDARKLY_ACCESS_TOKEN \ # example: api-xxxx
+  --projKey=$YOUR_LAUNCHDARKLY_PROJECT_KEY \ # example: my-project
+  --repoName=$YOUR_REPOSITORY_NAME \ # example: my-repo
+  --dir="/path/to/git/repo"
+  "branch1" "branch2"
+```

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -17,7 +17,7 @@ type Client struct {
 	GitSha    string
 }
 
-func NewClient(path string, branch string) (Client, error) {
+func NewClient(path string, branch string) (*Client, error) {
 	if !filepath.IsAbs(path) {
 		log.Error.Fatalf("expected an absolute path but received a relative path: %s", path)
 	}
@@ -26,16 +26,16 @@ func NewClient(path string, branch string) (Client, error) {
 
 	_, err := exec.LookPath("git")
 	if err != nil {
-		return client, errors.New("git is a required dependency, but was not found in the system PATH")
+		return &client, errors.New("git is a required dependency, but was not found in the system PATH")
 	}
 
 	var currBranch = branch
 	if branch == "" {
 		currBranch, err = client.branchName()
 		if err != nil {
-			return client, fmt.Errorf("error parsing git branch name: %s", err)
+			return &client, fmt.Errorf("error parsing git branch name: %s", err)
 		} else if currBranch == "" {
-			return client, fmt.Errorf("error parsing git branch name: git repo at %s must be checked out to a valid branch or --branch option must be set", client.workspace)
+			return &client, fmt.Errorf("error parsing git branch name: git repo at %s must be checked out to a valid branch or --branch option must be set", client.workspace)
 		}
 	}
 	log.Info.Printf("git branch: %s", currBranch)
@@ -43,14 +43,14 @@ func NewClient(path string, branch string) (Client, error) {
 
 	head, err := client.headSha()
 	if err != nil {
-		return client, fmt.Errorf("error parsing current commit sha: %s", err)
+		return &client, fmt.Errorf("error parsing current commit sha: %s", err)
 	}
 	client.GitSha = head
 
-	return client, nil
+	return &client, nil
 }
 
-func (c Client) branchName() (string, error) {
+func (c *Client) branchName() (string, error) {
 	/* #nosec */
 	cmd := exec.Command("git", "-C", c.workspace, "rev-parse", "--abbrev-ref", "HEAD")
 	out, err := cmd.CombinedOutput()
@@ -65,7 +65,7 @@ func (c Client) branchName() (string, error) {
 	return ret, nil
 }
 
-func (c Client) headSha() (string, error) {
+func (c *Client) headSha() (string, error) {
 	/* #nosec */
 	cmd := exec.Command("git", "-C", c.workspace, "rev-parse", "HEAD")
 	out, err := cmd.CombinedOutput()
@@ -77,7 +77,7 @@ func (c Client) headSha() (string, error) {
 	return ret, nil
 }
 
-func (c Client) RemoteBranches() (map[string]bool, error) {
+func (c *Client) RemoteBranches() (map[string]bool, error) {
 	/* #nosec */
 	cmd := exec.Command("git", "-C", c.workspace, "ls-remote", "--quiet", "--heads")
 	out, err := cmd.CombinedOutput()

--- a/internal/ld/ld.go
+++ b/internal/ld/ld.go
@@ -329,6 +329,8 @@ func (c ApiClient) do(req *h.Request) (*http.Response, error) {
 
 		if err == nil {
 			switch ldErr.Code {
+			case "invalid_request":
+				return res, errors.New(ldErr.Message)
 			case "updateSequenceId_conflict":
 				return res, BranchUpdateSequenceIdConflictErr
 			case "not_found":

--- a/internal/options/flags.go
+++ b/internal/options/flags.go
@@ -125,6 +125,12 @@ LaunchDarkly UI. Aceptable values: github|bitbucket|custom.`,
 bitbucket repository, LaunchDarkly will attempt to automatically generate source code links.`,
 	},
 	{
+		name:         "revision",
+		short:        "R",
+		defaultValue: "",
+		usage:        `The current revision of the repository to be scanned. If set, the version string for the scanned repository will not be inferred, and branch garbage collection will be disabled. Use this option to scan non-git codebases`,
+	},
+	{
 		name:         "updateSequenceId",
 		short:        "s",
 		defaultValue: -1,

--- a/internal/options/flags.go
+++ b/internal/options/flags.go
@@ -25,7 +25,7 @@ var flags = []flag{
 		name:         "branch",
 		short:        "b",
 		defaultValue: "",
-		usage: `The currently checked out git branch. If not provided, branch
+		usage: `The currently checked out branch. If not provided, branch
 name will be auto-detected. Provide this option when using CI systems that
 leave the repository in a detached HEAD state.`,
 	},
@@ -33,7 +33,7 @@ leave the repository in a detached HEAD state.`,
 		name:         "commitUrlTemplate",
 		defaultValue: "",
 		usage: `If provided, LaunchDarkly will attempt to generate links to
-your Git service provider per commit.
+your VCS service provider per commit.
 Example: https://github.com/launchdarkly/ld-find-code-refs/commit/${sha}.
 Allowed template variables: 'branchName', 'sha'. If commitUrlTemplate is
 not provided, but repoUrl is provided and repoType is not custom,
@@ -58,14 +58,14 @@ may be provided.`,
 		name:         "defaultBranch",
 		short:        "B",
 		defaultValue: "master",
-		usage: `The git default branch. The LaunchDarkly UI will default to this branch.
+		usage: `The default branch. The LaunchDarkly UI will default to this branch.
 If not provided, will fallback to 'master'.`,
 	},
 	{
 		name:         "dir",
 		short:        "d",
 		defaultValue: "",
-		usage:        "Path to existing checkout of the git repo.",
+		usage:        "Path to existing checkout of the repository.",
 	},
 	{
 		name:         "dryRun",
@@ -77,7 +77,7 @@ LaunchDarkly. Combine with the outDir option to output code references to a CSV.
 		name:         "hunkUrlTemplate",
 		defaultValue: "",
 		usage: `If provided, LaunchDarkly will attempt to generate links to 
-your Git service provider per code reference. 
+your VCS service provider per code reference. 
 Example: https://github.com/launchdarkly/ld-find-code-refs/blob/${sha}/${filePath}#L${lineNumber}.
 Allowed template variables: 'sha', 'filePath', 'lineNumber'. If hunkUrlTemplate is not provided, 
 but repoUrl is provided and repoType is not custom, LaunchDarkly will automatically generate
@@ -107,7 +107,7 @@ the project to this directory.`,
 		name:         "repoName",
 		short:        "r",
 		defaultValue: "",
-		usage: `Git repo name. Will be displayed in LaunchDarkly. Case insensitive.
+		usage: `Repository name. Will be displayed in LaunchDarkly. Case insensitive.
 Repo names must only contain letters, numbers, '.', '_' or '-'."`,
 	},
 	{

--- a/internal/options/flags.go
+++ b/internal/options/flags.go
@@ -128,7 +128,7 @@ bitbucket repository, LaunchDarkly will attempt to automatically generate source
 		name:         "revision",
 		short:        "R",
 		defaultValue: "",
-		usage:        `The current revision of the repository to be scanned. If set, the version string for the scanned repository will not be inferred, and branch garbage collection will be disabled. Use this option to scan non-git codebases`,
+		usage:        `Use this option to scan non-git codebases. The current revision of the repository to be scanned. If set, the version string for the scanned repository will not be inferred, and branch garbage collection will be disabled. The "branch" option is required when "revision" is set.`,
 	},
 	{
 		name:         "updateSequenceId",

--- a/internal/options/options.go
+++ b/internal/options/options.go
@@ -29,6 +29,7 @@ type Options struct {
 	RepoName            string `mapstructure:"repoName"`
 	RepoType            string `mapstructure:"repoType"`
 	RepoUrl             string `mapstructure:"repoUrl"`
+	Revision            string `mapstructure:"revision"`
 	ContextLines        int    `mapstructure:"contextLines"`
 	UpdateSequenceId    int    `mapstructure:"updateSequenceId"`
 	Debug               bool   `mapstructure:"debug"`
@@ -140,8 +141,7 @@ func GetWrapperOptions(dir string, merge func(Options) (Options, error)) (Option
 	return merge(opts)
 }
 
-// Validate ensures all options have been set to a valid value
-func (o Options) Validate() error {
+func (o Options) ValidateRequired() error {
 	missingRequiredOptions := []string{}
 	if o.AccessToken == "" {
 		missingRequiredOptions = append(missingRequiredOptions, "accessToken")
@@ -157,6 +157,15 @@ func (o Options) Validate() error {
 	}
 	if len(missingRequiredOptions) > 0 {
 		return fmt.Errorf("missing required option(s): %v", missingRequiredOptions)
+	}
+	return nil
+}
+
+// Validate ensures all options have been set to a valid value
+func (o Options) Validate() error {
+	err := o.ValidateRequired()
+	if err != nil {
+		return err
 	}
 
 	maxContextLines := 5
@@ -184,7 +193,7 @@ func (o Options) Validate() error {
 		}
 	}
 
-	_, err := validation.NormalizeAndValidatePath(o.Dir)
+	_, err = validation.NormalizeAndValidatePath(o.Dir)
 	if err != nil {
 		return fmt.Errorf(`invalid value for "dir": %+v`, err)
 	}
@@ -201,6 +210,10 @@ func (o Options) Validate() error {
 		if err != nil {
 			return err
 		}
+	}
+
+	if o.Revision != "" && o.Branch == "" {
+		return fmt.Errorf(`"branch" opton is required when "revision" option is set`)
 	}
 
 	return nil

--- a/internal/options/options.go
+++ b/internal/options/options.go
@@ -213,7 +213,7 @@ func (o Options) Validate() error {
 	}
 
 	if o.Revision != "" && o.Branch == "" {
-		return fmt.Errorf(`"branch" opton is required when "revision" option is set`)
+		return fmt.Errorf(`"branch" option is required when "revision" option is set`)
 	}
 
 	return nil


### PR DESCRIPTION
- Added support for scanning non-git repositories. Use the `--revision` flag to specify your repository version number. Setting this disables automatic branch pruning as ld-find-code-refs does not have a remote repository to generate a list of branches from.
- Added the `prune` sub-command to delete stale code reference data from LaunchDarkly manually by providing a list of branch names as arguments. example: `ld-find-code-refs prune [flags] branch1 branch2`

