### PR TITLE
Don't process symlink contents

### DIFF
--- a/internal/search/files.go
+++ b/internal/search/files.go
@@ -85,7 +85,7 @@ func readFiles(ctx context.Context, files chan<- file, workspace string) error {
 				return filepath.SkipDir
 			}
 			return nil
-		} else if isDir {
+		} else if isDir || info.Mode()&os.ModeSymlink == os.ModeSymlink {
 			return nil
 		}
 

--- a/internal/search/files_test.go
+++ b/internal/search/files_test.go
@@ -22,6 +22,8 @@ func Test_readFiles(t *testing.T) {
 			assert.Equal(t, testFile.lines, file.lines)
 		case "ignoredFiles/included":
 			assert.Equal(t, []string{"IGNORED BUT INCLUDED"}, file.lines)
+		case "symlink":
+			assert.Fail(t, "Should not read symlink contents")
 		default:
 			assert.Fail(t, "Read unexpected file", file)
 		}

--- a/internal/search/testdata/symlink
+++ b/internal/search/testdata/symlink
@@ -1,0 +1,1 @@
+fileWithRefs


### PR DESCRIPTION
Symlinks may be present in a repository, but typically should not be
processed as they may point to non-existent files (depending on the run
context) or other files in the same repository (which will be processed
independently).
