### PR TITLE
prepare 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the ld-find-code-refs program will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [2.0.1] - 2020-10-05
+
+### Fixed
+
+- Fixes a bug causing `ld-find-code-refs` to scan non-regular files, like symlinks. Thanks @d3d-z7n!
+
 ## [2.0.0] - 2020-08-13
 
 ℹ️ This release includes breaking changes to the command line tool. If you experience errors or unexpected behavior after upgrading, be sure to read these changelog notes carefully to make adjustments for any breaking changes.
@@ -13,7 +19,7 @@ All notable changes to the ld-find-code-refs program will be documented in this 
     - `--dir` / `LD_DIR`
     - `--accessToken` / `LD_ACCESS_TOKEN`
 - All command line flags can now be specified as environment variables. [docs](https://github.com/launchdarkly/ld-find-code-refs/blob/master/docs/CONFIGURATION.md#environment-variables)
-- When flags with no code references are detected, `ld-find-code-refs` will search Git commit history to detect when the last reference to a feature flag was removed. Use the `--lookback` command line flag to configure the number of commits you would like to search.  The lookback will start at the current commit and will review up to the last n commits to find the last reference of the flag.  The default is 10 commits. 
+- When flags with no code references are detected, `ld-find-code-refs` will search Git commit history to detect when the last reference to a feature flag was removed. Use the `--lookback` command line flag to configure the number of commits you would like to search. The lookback will start at the current commit and will review up to the last n commits to find the last reference of the flag. The default is 10 commits.
 - Added support for scanning non-git repositories. Use the `--revision` flag to specify your repository version number.
 - Added the `prune` sub-command to delete stale code reference data from LaunchDarkly manually by providing a list of branch names as arguments. example: `ld-find-code-refs prune [flags] "branch1" "branch2"`
 - The GitHub actions wrapper now supports the `pull_request` event

--- a/build/package/circleci/orb.yml
+++ b/build/package/circleci/orb.yml
@@ -9,7 +9,7 @@ examples:
     usage:
       version: 2.1
       orbs:
-        launchdarkly: launchdarkly/ld-find-code-refs@2.0.0
+        launchdarkly: launchdarkly/ld-find-code-refs@2.0.1
       workflows:
         main:
           jobs:
@@ -23,7 +23,7 @@ examples:
     usage:
       version: 2.1
       orbs:
-        launchdarkly: launchdarkly/ld-find-code-refs@2.0.0
+        launchdarkly: launchdarkly/ld-find-code-refs@2.0.1
       workflows:
         main:
           jobs:
@@ -38,7 +38,7 @@ examples:
     usage:
       version: 2.1
       orbs:
-        launchdarkly: launchdarkly/ld-find-code-refs@2.0.0
+        launchdarkly: launchdarkly/ld-find-code-refs@2.0.1
       workflows:
         main:
           jobs:
@@ -104,7 +104,7 @@ whether a feature flag was removed from code. May be set to 0 to disabled this f
         type: integer
         default: 10
     docker:
-      - image: launchdarkly/ld-find-code-refs:2.0.0
+      - image: launchdarkly/ld-find-code-refs:2.0.1
         entrypoint: sh
     steps:
       - checkout:

--- a/internal/search/files.go
+++ b/internal/search/files.go
@@ -85,7 +85,7 @@ func readFiles(ctx context.Context, files chan<- file, workspace string) error {
 				return filepath.SkipDir
 			}
 			return nil
-		} else if isDir || info.Mode()&os.ModeSymlink == os.ModeSymlink {
+		} else if !info.Mode().IsRegular() {
 			return nil
 		}
 

--- a/internal/search/files.go
+++ b/internal/search/files.go
@@ -85,7 +85,7 @@ func readFiles(ctx context.Context, files chan<- file, workspace string) error {
 				return filepath.SkipDir
 			}
 			return nil
-		} else if isDir {
+		} else if isDir || info.Mode()&os.ModeSymlink == os.ModeSymlink {
 			return nil
 		}
 

--- a/internal/search/files_test.go
+++ b/internal/search/files_test.go
@@ -22,6 +22,8 @@ func Test_readFiles(t *testing.T) {
 			assert.Equal(t, testFile.lines, file.lines)
 		case "ignoredFiles/included":
 			assert.Equal(t, []string{"IGNORED BUT INCLUDED"}, file.lines)
+		case "symlink":
+			assert.Fail(t, "Should not read symlink contents")
 		default:
 			assert.Fail(t, "Read unexpected file", file)
 		}

--- a/internal/search/testdata/symlink
+++ b/internal/search/testdata/symlink
@@ -1,0 +1,1 @@
+fileWithRefs

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "2.0.0"
+const Version = "2.0.1"


### PR DESCRIPTION
## [2.0.1] - 2020-10-05

### Fixed

- Fixes a bug causing `ld-find-code-refs` to scan non-regular files, like symlinks. Thanks @d3d-z7n!
