### PR TITLE
[ch99331] Support repoName in Github action yaml

### DIFF
--- a/build/package/bitbucket-pipelines/bitbucket-pipelines.go
+++ b/build/package/bitbucket-pipelines/bitbucket-pipelines.go
@@ -22,8 +22,10 @@ func main() {
 
 func mergeBitbucketOptions(opts o.Options) (o.Options, error) {
 	log.Info.Printf("Setting Bitbucket Pipelines env vars")
+	if opts.RepoName == "" {
+		opts.RepoName = os.Getenv("BITBUCKET_REPO_SLUG")
+	}
 	opts.RepoType = "bitbucket"
-	opts.RepoName = os.Getenv("BITBUCKET_REPO_SLUG")
 	opts.RepoUrl = os.Getenv("BITBUCKET_GIT_HTTP_ORIGIN")
 	updateSequenceId, err := strconv.Atoi(os.Getenv("BITBUCKET_BUILD_NUMBER"))
 	if err != nil {

--- a/build/package/bitbucket-pipelines/bitbucket-pipelines_test.go
+++ b/build/package/bitbucket-pipelines/bitbucket-pipelines_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/launchdarkly/ld-find-code-refs/internal/log"
+	o "github.com/launchdarkly/ld-find-code-refs/internal/options"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMain(m *testing.M) {
+	log.Init(true)
+	os.Exit(m.Run())
+}
+
+func TestMergeBitbucketOptions_withCliRepoName(t *testing.T) {
+	os.Setenv("BITBUCKET_GIT_HTTP_ORIGIN", "https://bitbucket.com/yus")
+	os.Setenv("BITBUCKET_BUILD_NUMBER", "100")
+	var options o.Options = o.Options{
+		AccessToken: "deaf-beef",
+		ProjKey:     "project-x",
+		RepoName:    "myapp-react",
+	}
+
+	result, _ := mergeBitbucketOptions(options)
+
+	assert.Equal(t, "myapp-react", result.RepoName)
+	assert.Equal(t, "bitbucket", result.RepoType)
+	assert.Equal(t, "https://bitbucket.com/yus", result.RepoUrl)
+	assert.Equal(t, 100, result.UpdateSequenceId)
+}
+
+func TestMergeBitbucketOptions_withBitbucketRepoName(t *testing.T) {
+	os.Setenv("BITBUCKET_GIT_HTTP_ORIGIN", "https://bitbucket.com/yus")
+	os.Setenv("BITBUCKET_BUILD_NUMBER", "200")
+	os.Setenv("BITBUCKET_REPO_SLUG", "myapp-vue")
+	var options o.Options = o.Options{
+		AccessToken: "deaf-beef",
+		ProjKey:     "project-x",
+	}
+
+	result, _ := mergeBitbucketOptions(options)
+
+	assert.Equal(t, "myapp-vue", result.RepoName)
+	assert.Equal(t, "bitbucket", result.RepoType)
+	assert.Equal(t, "https://bitbucket.com/yus", result.RepoUrl)
+	assert.Equal(t, 200, result.UpdateSequenceId)
+}

--- a/build/package/github-actions/github-actions.go
+++ b/build/package/github-actions/github-actions.go
@@ -30,10 +30,15 @@ func mergeGithubOptions(opts o.Options) (o.Options, error) {
 	log.Info.Printf("Setting GitHub action env vars")
 	ghRepo := strings.Split(os.Getenv("GITHUB_REPOSITORY"), "/")
 	repoName := ""
-	if len(ghRepo) > 1 {
-		repoName = ghRepo[1]
+
+	if opts.RepoName != "" {
+		repoName = opts.RepoName
 	} else {
-		log.Error.Printf("unable to validate GitHub repository name: %v", ghRepo)
+		if len(ghRepo) > 1 {
+			repoName = ghRepo[1]
+		} else {
+			log.Error.Printf("unable to validate GitHub repository name: %v", ghRepo)
+		}
 	}
 	event, err := parseEvent(os.Getenv("GITHUB_EVENT_PATH"))
 	if err != nil {

--- a/build/package/github-actions/github-actions_test.go
+++ b/build/package/github-actions/github-actions_test.go
@@ -1,10 +1,18 @@
 package main
 
 import (
+	"os"
 	"testing"
 
+	"github.com/launchdarkly/ld-find-code-refs/internal/log"
+	o "github.com/launchdarkly/ld-find-code-refs/internal/options"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestMain(m *testing.M) {
+	log.Init(true)
+	os.Exit(m.Run())
+}
 
 func TestParseBranch(t *testing.T) {
 	specs := []struct {
@@ -62,4 +70,26 @@ func TestParseBranch(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMergeGithubOptions_withCliRepoName(t *testing.T) {
+	os.Setenv("GITHUB_REF", "refs/heads/test")
+	var options o.Options = o.Options{
+		AccessToken: "deaf-beef",
+		ProjKey:     "project-x",
+		RepoName:    "myapp-react",
+	}
+	result, _ := mergeGithubOptions(options)
+	assert.Equal(t, "myapp-react", result.RepoName)
+}
+
+func TestMergeGithubOptions_withGithubRepoName(t *testing.T) {
+	os.Setenv("GITHUB_REPOSITORY", "yusinto/myapp-golang")
+	os.Setenv("GITHUB_REF", "refs/heads/test")
+	var options o.Options = o.Options{
+		AccessToken: "deaf-beef",
+		ProjKey:     "project-x",
+	}
+	result, _ := mergeGithubOptions(options)
+	assert.Equal(t, "myapp-golang", result.RepoName)
 }


### PR DESCRIPTION
[Escalated support ticket here.](https://app.clubhouse.io/launchdarkly/story/99331/support-escalation-setting-up-multiple-yaml-files-in-coderef-works-only-intermittently)

[Slack thread here.](https://launchdarkly.slack.com/archives/C4LUP9NPM/p1611795592035000?thread_ts=1611789046.030400&cid=C4LUP9NPM)

This PR then implements the solution agreed above on slack. In order to support monorepos, we expose repoName in our github action config yaml so a single repo can map to multiple projects.

If this is approved, I'll go ahead and submit a PR for the corresponding [documentation page.](https://docs.launchdarkly.com/home/code/github-actions)