### PR TITLE
[ch105727] Fix broken import statements in tests

### DIFF
--- a/build/package/bitbucket-pipelines/bitbucket-pipelines_test.go
+++ b/build/package/bitbucket-pipelines/bitbucket-pipelines_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/launchdarkly/ld-find-code-refs/internal/log"
-	o "github.com/launchdarkly/ld-find-code-refs/internal/options"
+	o "github.com/launchdarkly/ld-find-code-refs/options"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/build/package/github-actions/github-actions_test.go
+++ b/build/package/github-actions/github-actions_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/launchdarkly/ld-find-code-refs/internal/log"
-	o "github.com/launchdarkly/ld-find-code-refs/internal/options"
+	o "github.com/launchdarkly/ld-find-code-refs/options"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
[ch](https://app.clubhouse.io/launchdarkly/story/105727/fix-broken-internal-options-imports-in-tests)

The `options` package were moved up one level by a separate pr and this was not caught/resolved in my earlier pr. So this ticket fixes these import statements in the github action and bitbucket test files.