### PR TITLE
Update release readme

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -9,17 +9,24 @@ This project uses [goreleaser](https://goreleaser.com/) to generate github relea
 
 Make sure you update the changelog before generating a release.
 
-Once a release has been completed, update the [BitBucket pipelines](https://bitbucket.org/launchdarkly/ld-find-code-refs-pipe) repo with the new version number, and push a tag containing the version number along with your commit. Example release commit: https://bitbucket.org/launchdarkly/ld-find-code-refs-pipe/commits/0b1e920c7322cd495f4fc1a09d339342d32606e4
+Once a release has been completed:
+
+* update the [BitBucket pipelines](https://bitbucket.org/launchdarkly/ld-find-code-refs-pipe) repo with the new version number, and push a tag containing the version number along with your commit. Example release [commit](https://bitbucket.org/launchdarkly/ld-find-code-refs-pipe/commits/0b1e920c7322cd495f4fc1a09d339342d32606e4).
+
+* update the [Github Actions](https://github.com/launchdarkly/find-code-references) repo with the new version number, and push a tag containing the version number along with your commit. Example release [commit](https://github.com/launchdarkly/find-code-references/commit/7bf0c13ba5be822881571c6286cff5ba89f1227a).
 
 ## Docker Hub
 
-To push a new image version to Docker hub, run `make publish-cli-docker TAG=$VERSION` or `make publish-github-actions-docker TAG=$VERSION`, where `$VERSION` is the version you want to release. This will compile the ld-find-code-refs binary for either the base command line code ref finder or the github actions specialized finder, build a new image with your version tagged, and also point latest at that tag and push both latest and $VERSION to docker hub.
+To push a new image version to Docker hub, run `make publish-cli-docker TAG=$VERSION` or `make publish-github-actions-docker TAG=$VERSION` or `make publish-bitbucket-pipelines-docker TAG=$VERSION`, where `$VERSION` is the version you want to release. This will compile the ld-find-code-refs binary for either the base command line code ref finder or the github actions specialized finder, build a new image with your version tagged, and also point latest at that tag and push both latest and $VERSION to docker hub.
 
 ## CircleCI Orb Registry
 
 To publish the CircleCI Orb to the Orb registry, you'll need the [CircleCI CLI](https://circleci.com/docs/2.0/local-cli/) installed, and will need to run `circleci setup` and authenticate with a circle token that has github owner status.
 
 Run `make publish-dev-circle-orb TAG=$VERSION` or `make-publish-release-circle-orb TAG=$VERSION` to publish the orb to the orb registry, where `$VERSION` is the version you want to release. Running `publish-dev-circle-orb` will publish a development-tagged (e.g. `dev:0.0.1`) orb, which can be overwritten, and `publish-release-circle-orb` will publish a release version of the orb, which is immutable. Both dev and release orbs are open to the public, but development orbs are not visible in the list of registered orbs on Circle's [website](https://circleci.com/orbs/registry/?showAll=true).
+
+## Release checklist
+Finally, follow the comprehensive checklist [here](https://launchdarkly.atlassian.net/wiki/spaces/ENG/pages/938214176/ld-find-code-refs+release+checklist) to make sure you have completed all the necessary steps.
 
 ## Beta builds
 


### PR DESCRIPTION
This updates the release readme with steps to update the github action `find-code-refs` repo and also includes the release checklist from confluence.