### PR TITLE
Build a map of flags to delimiters

### DIFF
--- a/coderefs/coderefs.go
+++ b/coderefs/coderefs.go
@@ -99,7 +99,8 @@ func Scan(opts options.Options) {
 	}
 	delims = append(delims, opts.Delimiters.Additional...)
 	delimString := strings.Join(helpers.Dedupe(delims), "")
-	refs, err := search.SearchForRefs(projKey, absPath, aliases, ctxLines, delimString)
+	delimiterMap := search.BuildDelimiterList(filteredFlags, delimString)
+	refs, err := search.SearchForRefs(projKey, absPath, aliases, ctxLines, delimString, delimiterMap)
 	if err != nil {
 		log.Error.Fatalf("error searching for flag key references: %s", err)
 	}

--- a/search/search_test.go
+++ b/search/search_test.go
@@ -132,10 +132,9 @@ func Test_hunkForLine(t *testing.T) {
 			ctxLines:     0,
 			lineNum:      0,
 			flagKey:      testFlagKey,
-			delimiters:   defaultDelims,
 			delimiterMap: defaultDelimsMap,
-			lines:        []string{delimitedTestFlagKey + strings.Repeat("a", maxLineCharCount)},
-			want:         makeHunkPtr(1, delimitedTestFlagKey+strings.Repeat("a", maxLineCharCount-len(delimitedTestFlagKey))+"…"),
+			lines:        []string{testFlagKey + strings.Repeat("a", maxLineCharCount)},
+			want:         makeHunkPtr(1, testFlagKey+strings.Repeat("a", maxLineCharCount-len(testFlagKey))+"…"),
 		},
 	}
 

--- a/search/search_test.go
+++ b/search/search_test.go
@@ -320,7 +320,7 @@ func Test_processFiles(t *testing.T) {
 
 func Test_SearchForRefs(t *testing.T) {
 	want := []ld.ReferenceHunksRep{{Path: testFile.path}}
-	got, err := SearchForRefs("default", "testdata", aliases, 0, defaultDelims, defaultDelimsMap)
+	got, err := SearchForRefs("default", "testdata", aliases, 0, "", defaultDelimsMap)
 	require.NoError(t, err)
 	require.Len(t, got, 1)
 	require.Equal(t, want[0].Path, got[0].Path)


### PR DESCRIPTION
Instead of rebuilding the strings each time we can build it once before scanning code and then look up that flag key in the map.
