### PR TITLE
Build map of delimiters once

### DIFF
--- a/search/matcher.go
+++ b/search/matcher.go
@@ -85,7 +85,6 @@ func buildDelimiterList(flags []string, delimiters string) map[string][]string {
 		return delimiterMap
 	}
 	for _, flag := range flags {
-		//flagsDelimited := []string{}
 		tempFlags := []string{}
 		for _, left := range delimiters {
 			for _, right := range delimiters {

--- a/search/matcher.go
+++ b/search/matcher.go
@@ -33,7 +33,6 @@ func Scan(opts options.Options, repoParams ld.RepoParams) (Matcher, []ld.Referen
 	flagMatcher.Elements, flagMatcher.Aliases = flags.GenerateSearchElements(opts, repoParams)
 
 	matcher := Matcher{
-		Elements: []ElementMatcher{flagMatcher},
 		CtxLines: opts.ContextLines,
 	}
 
@@ -42,6 +41,8 @@ func Scan(opts options.Options, repoParams ld.RepoParams) (Matcher, []ld.Referen
 	matcher.Delimiters = strings.Join(helpers.Dedupe(delims), "")
 	flagMatcher.DelimitedFlags = buildDelimiterList(flagMatcher.Elements, matcher.Delimiters)
 	// Begin search for elements.
+	matcher.Elements = []ElementMatcher{flagMatcher}
+
 	refs, err := SearchForRefs(matcher)
 	if err != nil {
 		log.Error.Fatalf("error searching for flag key references: %s", err)
@@ -68,7 +69,6 @@ func (m Matcher) MatchElement(line, flagKey string) bool {
 
 	for _, element := range m.Elements {
 		delimitedFlags := element.DelimitedFlags[flagKey]
-
 		for _, delimitedflagKey := range delimitedFlags {
 			if strings.Contains(line, delimitedflagKey) {
 				return true

--- a/search/matcher.go
+++ b/search/matcher.go
@@ -11,11 +11,12 @@ import (
 )
 
 type ElementMatcher struct {
-	Elements   []string
-	Aliases    map[string][]string
-	Delimiters []string
-	ProjKey    string
-	Directory  string
+	Elements       []string
+	Aliases        map[string][]string
+	Delimiters     []string
+	ProjKey        string
+	Directory      string
+	DelimitedFlags map[string][]string
 }
 
 type Matcher struct {
@@ -39,7 +40,7 @@ func Scan(opts options.Options, repoParams ld.RepoParams) (Matcher, []ld.Referen
 	// Configure delimiters
 	delims := getDelimiters(opts)
 	matcher.Delimiters = strings.Join(helpers.Dedupe(delims), "")
-
+	flagMatcher.DelimitedFlags = buildDelimiterList(flagMatcher.Elements, matcher.Delimiters)
 	// Begin search for elements.
 	refs, err := SearchForRefs(matcher)
 	if err != nil {
@@ -64,17 +65,39 @@ func (m Matcher) MatchElement(line, flagKey string) bool {
 	if m.Delimiters == "" && strings.Contains(line, flagKey) {
 		return true
 	}
-	for _, left := range m.Delimiters {
-		for _, right := range m.Delimiters {
-			var sb strings.Builder
-			sb.Grow(len(flagKey) + 2)
-			sb.WriteRune(left)
-			sb.WriteString(flagKey)
-			sb.WriteRune(right)
-			if strings.Contains(line, sb.String()) {
+
+	for _, element := range m.Elements {
+		delimitedFlags := element.DelimitedFlags[flagKey]
+
+		for _, delimitedflagKey := range delimitedFlags {
+			if strings.Contains(line, delimitedflagKey) {
 				return true
 			}
 		}
 	}
+
 	return false
+}
+
+func buildDelimiterList(flags []string, delimiters string) map[string][]string {
+	delimiterMap := make(map[string][]string)
+	if delimiters == "" {
+		return delimiterMap
+	}
+	for _, flag := range flags {
+		//flagsDelimited := []string{}
+		tempFlags := []string{}
+		for _, left := range delimiters {
+			for _, right := range delimiters {
+				var sb strings.Builder
+				sb.Grow(len(flag) + 2)
+				sb.WriteRune(left)
+				sb.WriteString(flag)
+				sb.WriteRune(right)
+				tempFlags = append(tempFlags, sb.String())
+			}
+		}
+		delimiterMap[flag] = tempFlags
+	}
+	return delimiterMap
 }

--- a/search/matcher_test.go
+++ b/search/matcher_test.go
@@ -1,0 +1,14 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_buildDelimiterList(t *testing.T) {
+	testFlagKey := "testflag"
+	delimitedFlag := buildDelimiterList([]string{testFlagKey}, defaultDelims)
+	want := map[string][]string{"testflag": []string{"\"testflag\"", "\"testflag'", "\"testflag`", "'testflag\"", "'testflag'", "'testflag`", "`testflag\"", "`testflag'", "`testflag`"}}
+	require.Equal(t, want, delimitedFlag)
+}

--- a/search/search_test.go
+++ b/search/search_test.go
@@ -80,7 +80,8 @@ func Test_hunkForLine(t *testing.T) {
 				CtxLines:   0,
 				Delimiters: defaultDelims,
 				Elements: []ElementMatcher{{
-					Aliases: aliases,
+					Aliases:        aliases,
+					DelimitedFlags: makeKeyMap(delimitedTestFlagKey),
 				}},
 			},
 			lineNum: 0,
@@ -448,4 +449,11 @@ func makeHunk(startingLineNumber int, lines ...string) ld.HunkRep {
 
 func delimit(s string, delim string) string {
 	return delim + s + delim
+}
+
+func makeKeyMap(flagKey string) map[string][]string {
+	keys := make(map[string][]string)
+	mapKey := strings.Trim(flagKey, `"`)
+	keys[mapKey] = []string{flagKey}
+	return keys
 }


### PR DESCRIPTION
sc119754

### Summary
* Update Code References so it only builds the map of delimiters a single time instead of repeatedly when scanning each line for flags.

### Testing
Updated test and added a new test for private function.