### PR TITLE
docs: migrate formula to homebrew-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ All turn-key configuration methods (docker images used by services like CircleCI
 #### macOS
 
 ```bash
-brew tap launchdarkly/tap
 brew install ld-find-code-refs
 ```
 


### PR DESCRIPTION
relates to https://github.com/Homebrew/homebrew-core/pull/88047