### PR TITLE
Support tags as "branch" name in coderefs

### DIFF
--- a/build/package/circleci/orb.yml
+++ b/build/package/circleci/orb.yml
@@ -90,6 +90,10 @@ jobs:
         description: "If provided, LaunchDarkly will attempt to generate links to your Git service provider per code reference. Example: `https://github.com/launchdarkly/ld-find-code-refs/blob/${sha}/${filePath}#L${lineNumber}`. Allowed template variables: `sha`, `filePath`, `lineNumber`. If `hunkUrlTemplate` is not provided, but `repoUrl` is provided, LaunchDarkly will automatically generate links for github or bitbucket repo types."
         type: string
         default: ""
+      allow_tags:
+        description: "Enables storing references for tags. The tag will be listed as a branch."
+        type: boolean
+        default: false
       debug:
         description: "Enables verbose debug logging."
         type: boolean
@@ -123,6 +127,7 @@ whether a feature flag was removed from code. May be set to 0 to disabled this f
               --repoType=<< parameters.repo_type >> \
               --repoUrl=<< parameters.repo_url >> \
               --defaultBranch=<< parameters.default_branch >> \
+              --allowTags=<< parameters.allow_tags >> \
               --commitUrlTemplate=<< parameters.commit_url_template >> \
               --hunkUrlTemplate=<< parameters.hunk_url_template >> \
               --repoName=${CIRCLE_PROJECT_REPONAME} \

--- a/build/package/github-actions/github-actions_test.go
+++ b/build/package/github-actions/github-actions_test.go
@@ -18,50 +18,95 @@ func TestParseBranch(t *testing.T) {
 	specs := []struct {
 		name        string
 		in          string
+		allowTags   bool
 		event       *Event
 		expectedOut string
 		expectError bool
 	}{
 		{
-			name:        "succeeds for well formed input",
+			name:        "succeeds for well formed branch input",
 			in:          "refs/heads/a",
+			allowTags:   false,
+			expectedOut: "a",
+			expectError: false,
+		},
+		{
+			name:        "succeeds for well formed branch input when tags are enabled",
+			in:          "refs/heads/a",
+			allowTags:   true,
+			expectedOut: "a",
+			expectError: false,
+		},
+		{
+			name:        "succeeds for well formed tag input when tags are enabled",
+			in:          "refs/tags/a",
+			allowTags:   true,
 			expectedOut: "a",
 			expectError: false,
 		},
 		{
 			name:        "works for branches with slashes",
 			in:          "refs/heads/a/b",
+			allowTags:   false,
 			expectedOut: "a/b",
 			expectError: false,
 		},
 		{
 			name:        "works for branches with different character types",
 			in:          "refs/heads/a-b.1+*",
+			allowTags:   false,
 			expectedOut: "a-b.1+*",
 			expectError: false,
 		},
 		{
 			name:        "returns an error for poorly formed input",
 			in:          "notaref",
+			allowTags:   false,
 			expectedOut: "",
 			expectError: true,
 		},
 		{
 			name:        "returns an error for an empty branch name",
 			in:          "refs/heads/",
+			allowTags:   false,
 			expectedOut: "",
 			expectError: true,
 		},
 		{
 			name:        "returns the event branch name for an invalid GITHUB_REF",
 			in:          "refs/pull/1",
+			allowTags:   false,
 			expectedOut: "master",
+			expectError: false,
 			event:       &Event{Pull: &Pull{Head: Head{Ref: "master"}}},
+		},
+		{
+			name:        "returns the event tag name for an invalid GITHUB_REF",
+			in:          "random",
+			allowTags:   true,
+			expectedOut: "v1.0.0",
+			expectError: false,
+			event:       &Event{Release: &Release{TagName: "v1.0.0"}},
+		},
+		{
+			name:        "returns an err for tags when tags are not allowed",
+			in:          "refs/tags/a",
+			allowTags:   false,
+			expectedOut: "",
+			expectError: true,
+		},
+		{
+			name:        "returns an err for tags when tags are not allowed, even when event has tag name",
+			in:          "random",
+			allowTags:   false,
+			expectedOut: "",
+			expectError: true,
+			event:       &Event{Release: &Release{TagName: "v1.0.0"}},
 		},
 	}
 	for _, tt := range specs {
 		t.Run(tt.name, func(t *testing.T) {
-			out, err := parseBranch(tt.in, tt.event)
+			out, err := parseBranch(tt.in, tt.event, tt.allowTags)
 			if tt.expectError {
 				assert.Error(t, err)
 			} else {

--- a/coderefs/coderefs.go
+++ b/coderefs/coderefs.go
@@ -28,7 +28,7 @@ func Run(opts options.Options) {
 	revision := opts.Revision
 	var gitClient *git.Client
 	if revision == "" {
-		gitClient, err = git.NewClient(absPath, branchName)
+		gitClient, err = git.NewClient(absPath, branchName, opts.AllowTags)
 		if err != nil {
 			log.Error.Fatalf("%s", err)
 		}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -31,6 +31,8 @@ Flags:
 ```
   -t, --accessToken string         LaunchDarkly personal access token with write-level access.
 
+      --allowTags                  Enables storing references for tags. The tag will be listed as a branch.
+
   -U, --baseUri string             LaunchDarkly base URI. (default "https://app.launchdarkly.com")
 
   -b, --branch string              The currently checked out branch. If not provided, branch name will be auto-detected. Provide this option when using CI systems that leave the repository in a detached HEAD state.

--- a/options/flags.go
+++ b/options/flags.go
@@ -16,6 +16,11 @@ var flags = []flag{
 		usage:        "LaunchDarkly personal access token with write-level access.",
 	},
 	{
+		name:         "allowTags",
+		defaultValue: false,
+		usage:        "Enables storing references for tags. The tag will be listed as a branch.",
+	},
+	{
 		name:         "baseUri",
 		short:        "U",
 		defaultValue: "https://app.launchdarkly.com",

--- a/options/options.go
+++ b/options/options.go
@@ -37,6 +37,7 @@ type Options struct {
 	ContextLines        int    `mapstructure:"contextLines"`
 	Lookback            int    `mapstructure:"lookback"`
 	UpdateSequenceId    int    `mapstructure:"updateSequenceId"`
+	AllowTags           bool   `mapstructure:"allowTags"`
 	Debug               bool   `mapstructure:"debug"`
 	DryRun              bool   `mapstructure:"dryRun"`
 	IgnoreServiceErrors bool   `mapstructure:"ignoreServiceErrors"`


### PR DESCRIPTION
Allow tags to be used as "branches"

1. When `--branch` is not set, and repo is in detached HEAD state, will detect a tag as a fallback
2. In github actions a `refs/tags/xxx` `GITHUB_REF` will be parsed as valid

--

too use run command with `--allowTags` or `--allowTags=true`

This resolves issue #155 