### PR TITLE
Update Tests

### DIFF
--- a/.ldrelease/test.sh
+++ b/.ldrelease/test.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-echo "tests are run in CirleCI"
-exit 0

--- a/search/search_test.go
+++ b/search/search_test.go
@@ -402,6 +402,7 @@ func Test_processFiles(t *testing.T) {
 }
 
 func Test_SearchForRefs(t *testing.T) {
+	os.Symlink("testdata/fileWithRefs", "testdata/symlink")
 	want := []ld.ReferenceHunksRep{{Path: testFile.path}}
 	matcher := Matcher{
 		CtxLines:   0,
@@ -412,6 +413,7 @@ func Test_SearchForRefs(t *testing.T) {
 		Directory: "testdata",
 		ProjKey:   "default",
 	})
+	t.Cleanup(func() { os.Remove("testdata/symlink") })
 	got, err := SearchForRefs(matcher)
 	require.NoError(t, err)
 	require.Len(t, got, 1)

--- a/search/testdata/symlink
+++ b/search/testdata/symlink
@@ -1,1 +1,0 @@
-fileWithRefs


### PR DESCRIPTION
This removes the symlink that exists in the test data and only creates it during the test run.