### PR TITLE
Add nil check on Alias Path and test coverage

### DIFF
--- a/aliases/alias.go
+++ b/aliases/alias.go
@@ -129,7 +129,7 @@ func processFileContent(aliases []options.Alias, dir string) (map[string][]byte,
 		for _, glob := range a.Paths {
 			absGlob := filepath.Join(dir, glob)
 			matches, err := filepath.Glob(absGlob)
-			if err != nil {
+			if matches == nil || err != nil {
 				return nil, fmt.Errorf("filepattern '%s': could not process path glob '%s'", aliasId, absGlob)
 			}
 			paths = append(paths, matches...)


### PR DESCRIPTION
If a directory or file does not exist in part of the Alias config FilePattern we should return an error.