### PR TITLE
Add make command for updating github action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build/package/cmd/ld-find-code-refs
 .idea/
 *.csv
 /internal/git/testdata/repo
+find-code-references


### PR DESCRIPTION
Add a single make command to increment the github action and update the container. This step is not part of the automated release yet. We can either add that into this PR or a separate followup.