### PR TITLE
Dob/sc 134515/relative path

### DIFF
--- a/coderefs/coderefs.go
+++ b/coderefs/coderefs.go
@@ -15,7 +15,7 @@ import (
 )
 
 func Run(opts options.Options) {
-	dir := opts.Dir
+	dir, _ := validation.NormalizeAndValidatePath(opts.Dir)
 	absPath, err := validation.NormalizeAndValidatePath(dir)
 	if err != nil {
 		log.Error.Fatalf("could not validate directory option: %s", err)
@@ -45,7 +45,7 @@ func Run(opts options.Options) {
 		DefaultBranch:     opts.DefaultBranch,
 	}
 
-	matcher, refs := search.Scan(opts, repoParams)
+	matcher, refs := search.Scan(opts, repoParams, dir)
 
 	var updateId *int
 	if opts.UpdateSequenceId >= 0 {

--- a/options/options.go
+++ b/options/options.go
@@ -208,7 +208,7 @@ func (o Options) Validate() error {
 		}
 	}
 
-	_, err = validation.NormalizeAndValidatePath(o.Dir)
+	o.Dir, err = validation.NormalizeAndValidatePath(o.Dir)
 	if err != nil {
 		return fmt.Errorf(`invalid value for "dir": %+v`, err)
 	}

--- a/options/options.go
+++ b/options/options.go
@@ -208,7 +208,7 @@ func (o Options) Validate() error {
 		}
 	}
 
-	o.Dir, err = validation.NormalizeAndValidatePath(o.Dir)
+	_, err = validation.NormalizeAndValidatePath(o.Dir)
 	if err != nil {
 		return fmt.Errorf(`invalid value for "dir": %+v`, err)
 	}

--- a/search/matcher.go
+++ b/search/matcher.go
@@ -30,9 +30,9 @@ type Matcher struct {
 }
 
 // Scan checks the configured directory for flags base on the options configured for Code References.
-func Scan(opts options.Options, repoParams ld.RepoParams) (Matcher, []ld.ReferenceHunksRep) {
+func Scan(opts options.Options, repoParams ld.RepoParams, dir string) (Matcher, []ld.ReferenceHunksRep) {
 	flagKeys := flags.GetFlagKeys(opts, repoParams)
-	aliasesByFlagKey, err := aliases.GenerateAliases(flagKeys, opts.Aliases, opts.Dir)
+	aliasesByFlagKey, err := aliases.GenerateAliases(flagKeys, opts.Aliases, dir)
 	if err != nil {
 		log.Error.Fatalf("failed to generate aliases: %s", err)
 	}
@@ -44,7 +44,7 @@ func Scan(opts options.Options, repoParams ld.RepoParams) (Matcher, []ld.Referen
 		Elements: []ElementMatcher{flagMatcher},
 	}
 
-	refs, err := SearchForRefs(opts.Dir, matcher)
+	refs, err := SearchForRefs(dir, matcher)
 	if err != nil {
 		log.Error.Fatalf("error searching for flag key references: %s", err)
 	}


### PR DESCRIPTION
We validated `options.Dir` in the validation handler, but that value is left unchanged. Elsewhere we were passing in the original `opts.Dir` which was not being expanded to a full absolute path. This changes it by using `NormalizeAndValidatePath` inside of `Run` to pass the absolute path to subsequent functions.