### PR TITLE
[sc-133063] Automate circleci orb publishing

### DIFF
--- a/.ldrelease/install-circleci.sh
+++ b/.ldrelease/install-circleci.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+# Install the CircleCI CLI tool.
+# https://github.com/CircleCI-Public/circleci-cli
+#
+# Dependencies: curl, cut
+#
+# The version to install and the binary location can be passed in via VERSION and DESTDIR respectively.
+#
+
+set -o errexit
+
+echo "Starting installation."
+
+# GitHub's URL for the latest release, will redirect.
+GITHUB_BASE_URL="https://github.com/CircleCI-Public/circleci-cli"
+LATEST_URL="${GITHUB_BASE_URL}/releases/latest/"
+DESTDIR="${DESTDIR:-/usr/local/bin}"
+
+if [ -z "$VERSION" ]; then
+	VERSION=$(curl -sLI -o /dev/null -w '%{url_effective}' "$LATEST_URL" | cut -d "v" -f 2)
+fi
+
+echo "Installing CircleCI CLI v${VERSION}"
+
+# Run the script in a temporary directory that we know is empty.
+SCRATCH=$(mktemp -d || mktemp -d -t 'tmp')
+cd "$SCRATCH"
+
+function error {
+  echo "An error occured installing the tool."
+  echo "The contents of the directory $SCRATCH have been left in place to help to debug the issue."
+}
+
+trap error ERR
+
+# Determine release filename. This can be expanded with CPU arch in the future.
+case "$(uname)" in
+	Linux)
+		OS='linux'
+	;;
+	Darwin)
+		OS='darwin'
+	;;
+	*)
+		echo "This operating system is not supported."
+		exit 1
+	;;
+esac
+
+RELEASE_URL="${GITHUB_BASE_URL}/releases/download/v${VERSION}/circleci-cli_${VERSION}_${OS}_amd64.tar.gz"
+
+# Download & unpack the release tarball.
+curl -sL --retry 3 "${RELEASE_URL}" | tar zx --strip 1
+
+echo "Installing to $DESTDIR"
+install circleci "$DESTDIR"
+
+command -v circleci
+
+# Delete the working directory when the install was successful.
+rm -r "$SCRATCH"

--- a/.ldrelease/publish-circleci.sh
+++ b/.ldrelease/publish-circleci.sh
@@ -3,7 +3,8 @@
 # Run this in publish step after all version information have been updated.
 set -ev
 
-brew install circleci
+sudo apt install curl
+curl -fLSs https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh | sudo bash
 
 # Read 2 arguments from the command line so we can debug this script.
 # Argument 1 is the release version. Defaults to releaser env variable.

--- a/.ldrelease/publish-circleci.sh
+++ b/.ldrelease/publish-circleci.sh
@@ -4,7 +4,7 @@
 set -ev
 
 sudo apt install curl
-curl -fLSs https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh | sudo bash
+./install-circleci
 
 # Read 2 arguments from the command line so we can debug this script.
 # Argument 1 is the release version. Defaults to releaser env variable.

--- a/.ldrelease/publish-circleci.sh
+++ b/.ldrelease/publish-circleci.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Run this in publish step after all version information have been updated.
+set -ev
+
+brew install circleci
+
+# Read 2 arguments from the command line so we can debug this script.
+# Argument 1 is the release version. Defaults to releaser env variable.
+RELEASE_VERSION=${1:-$LD_RELEASE_VERSION}
+
+# Argument 2 is the circleci token. Defaults releaser circleci secret.
+CIRCLECI_CLI_TOKEN=${2:-"${LD_RELEASE_SECRETS_DIR}/circleci_token"}
+CIRCLECI_CLI_HOST="https://circleci.com"
+
+# Validate circleci orb config. No publishing done on this step.
+circleci orb validate build/package/circleci/orb.yml || (echo "Unable to validate orb"; exit 1)
+
+# dev publish only, not production
+circleci orb publish build/package/circleci/orb.yml launchdarkly/ld-find-code-refs@dev:$RELEASE_VERSION --token $CIRCLECI_CLI_TOKEN --host $CIRCLECI_CLI_HOST
+
+# TODO: uncomment this once we have the circleci token in SSM.
+#circleci orb publish build/package/circleci/orb.yml launchdarkly/ld-find-code-refs@$RELEASE_VERSION --token $CIRCLECI_CLI_TOKEN --host $CIRCLECI_CLI_HOST

--- a/.ldrelease/publish.sh
+++ b/.ldrelease/publish.sh
@@ -3,6 +3,7 @@
 # the "publish" makefile target pushes the image to Docker
 $(dirname $0)/run-publish-target.sh publish
 
-# TODO: publish metadata changes to github actions and bitbucket marketplaces
+# TODO: publish to github actions, bitbucket and circleci marketplaces
 #./publish-github-actions-metadata.sh
 #./publish-bitbucket-metadata.sh
+#./publish-circleci.sh

--- a/.ldrelease/secrets.properties
+++ b/.ldrelease/secrets.properties
@@ -2,3 +2,4 @@
 docker_username=param:/global/services/docker/public/username
 docker_token=param:/global/services/docker/public/token
 github_token=param:/staging/common/services/github/releaser_access_token
+circleci_token=param:/production/common/releasing/circleci/token

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,8 @@ define publish_docker
 	test $(2) || docker push launchdarkly/$(3):latest
 endef
 
+# TODO: Remove all circleci publishing targets when we have a github owner token setup.
+# Use ./ldrelease/publish-circleci.sh to publish to circleci orbs registry.
 validate-circle-orb:
 	test $(TAG) || (echo "Please provide tag"; exit 1)
 	circleci orb validate build/package/circleci/orb.yml || (echo "Unable to validate orb"; exit 1)


### PR DESCRIPTION
Note that the prerequisite of this work is having a github owner circleci token. There is a [security review](https://launchdarkly.atlassian.net/browse/SEC-773) for this. In the meantime to test this, we can a dev version of the orb.

This pr migrates existing Circleci shell commands to built-in releaser steps:

1. (Done in past pr) Modify`update-version.sh` to update version numbers in circleci/orb.yml.
2. Modify `publish.sh` to install the circleci cli
3. Modify `publish.sh` to run circleci setup authenticating with a circleci token that has the github owner role.
4. Modify `publish.sh` to run circleci orb publish
