### PR TITLE
Generate Hash of contents

### DIFF
--- a/internal/ld/ld.go
+++ b/internal/ld/ld.go
@@ -490,7 +490,7 @@ func (b BranchRep) WriteToCSV(outDir, repo, sha string) (path string, err error)
 		return false
 	})
 
-	records = append([][]string{{"flagKey", "projKey", "path", "startingLineNumber", "lines", "aliases"}}, records...)
+	records = append([][]string{{"flagKey", "projKey", "path", "startingLineNumber", "lines", "aliases", "contentHash"}}, records...)
 	return path, w.WriteAll(records)
 }
 

--- a/internal/ld/ld.go
+++ b/internal/ld/ld.go
@@ -502,7 +502,7 @@ type ReferenceHunksRep struct {
 func (r ReferenceHunksRep) toRecords() [][]string {
 	ret := make([][]string, 0, len(r.Hunks))
 	for _, hunk := range r.Hunks {
-		ret = append(ret, []string{hunk.FlagKey, hunk.ProjKey, r.Path, strconv.FormatInt(int64(hunk.StartingLineNumber), 10), hunk.Lines, strings.Join(hunk.Aliases, " ")})
+		ret = append(ret, []string{hunk.FlagKey, hunk.ProjKey, r.Path, strconv.FormatInt(int64(hunk.StartingLineNumber), 10), hunk.Lines, strings.Join(hunk.Aliases, " "), hunk.ContentHash})
 	}
 	return ret
 }
@@ -513,6 +513,7 @@ type HunkRep struct {
 	ProjKey            string   `json:"projKey"`
 	FlagKey            string   `json:"flagKey"`
 	Aliases            []string `json:"aliases,omitempty"`
+	ContentHash        string   `json:"contentHash,omitempty"`
 }
 
 // Returns the number of lines overlapping between the receiver (h) and the parameter (hr) hunkreps

--- a/search/search.go
+++ b/search/search.go
@@ -95,7 +95,6 @@ func (f file) aggregateHunksForFlag(projKey, flagKey string, matcher Matcher, li
 			if lastHunkIdx >= 0 && hunksForFlag[lastHunkIdx].Overlap(*match) >= 0 {
 				hunksForFlag = append(hunksForFlag[:lastHunkIdx], mergeHunks(hunksForFlag[lastHunkIdx], *match)...)
 			} else {
-				match.ContentHash = getContentHash(match.Lines)
 				hunksForFlag = append(hunksForFlag, *match)
 			}
 		}

--- a/search/search_test.go
+++ b/search/search_test.go
@@ -420,12 +420,14 @@ func makeHunk(startingLineNumber int, lines ...string) ld.HunkRep {
 	if len(lines) != 0 {
 		hunkLines = strings.Join(lines, "\n")
 	}
+
 	return ld.HunkRep{
 		ProjKey:            "default",
 		FlagKey:            testFlagKey,
 		StartingLineNumber: startingLineNumber,
 		Lines:              hunkLines,
 		Aliases:            []string{},
+		ContentHash:        getContentHash(hunkLines),
 	}
 }
 


### PR DESCRIPTION
Use git's underlying functionality to generate a consistent hash of the the lines of content across runs.