### PR TITLE
match Extinction time rep

### DIFF
--- a/coderefs/coderefs.go
+++ b/coderefs/coderefs.go
@@ -3,7 +3,6 @@ package coderefs
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/launchdarkly/ld-find-code-refs/internal/git"
 	"github.com/launchdarkly/ld-find-code-refs/internal/helpers"
@@ -32,7 +31,7 @@ func Run(opts options.Options) {
 	branchName := opts.Branch
 	revision := opts.Revision
 	var gitClient *git.Client
-	var commitTime *time.Time
+	var commitTime int64
 	if revision == "" {
 		gitClient, err = git.NewClient(absPath, branchName, opts.AllowTags)
 		if err != nil {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"time"
 
 	git "github.com/go-git/go-git/v5"
 	object "github.com/go-git/go-git/v5/plumbing/object"
@@ -25,7 +24,7 @@ type Client struct {
 	workspace    string
 	GitBranch    string
 	GitSha       string
-	GitTimestamp *time.Time
+	GitTimestamp int64
 }
 
 func NewClient(path string, branch string, allowTags bool) (*Client, error) {
@@ -134,20 +133,21 @@ func (c *Client) headSha() (string, error) {
 	return ret, nil
 }
 
-func (c *Client) commitTime() (*time.Time, error) {
+func (c *Client) commitTime() (int64, error) {
 	repo, err := git.PlainOpen(c.workspace)
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
 	head, err := repo.Head()
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
 	commit, err := repo.CommitObject(head.Hash())
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
-	return &commit.Author.When, nil
+	commitTime := commit.Author.When.Unix() * 1000
+	return commitTime, nil
 }
 
 func (c *Client) RemoteBranches() (map[string]bool, error) {

--- a/internal/ld/ld.go
+++ b/internal/ld/ld.go
@@ -16,7 +16,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"time"
 
 	h "github.com/hashicorp/go-retryablehttp"
 	"github.com/olekukonko/tablewriter"
@@ -446,7 +445,7 @@ type BranchRep struct {
 	UpdateSequenceId *int                `json:"updateSequenceId,omitempty"`
 	SyncTime         int64               `json:"syncTime"`
 	References       []ReferenceHunksRep `json:"references,omitempty"`
-	CommitTime       *time.Time          `json:"commitTime,omitempty"`
+	CommitTime       int64               `json:"commitTime,omitempty"`
 }
 
 func (b BranchRep) TotalHunkCount() int {


### PR DESCRIPTION
This is functionally the same as the current implementation for getting time but changed to use `int64` as it matches how Extinctions track their current time: https://github.com/launchdarkly/ld-find-code-refs/blob/master/internal/git/git.go#L243