### PR TITLE
[sc-136606] Circleci publishing fixes

### DIFF
--- a/.ldrelease/publish-circleci.sh
+++ b/.ldrelease/publish-circleci.sh
@@ -4,7 +4,7 @@
 set -ev
 
 sudo apt install curl
-./install-circleci
+./.ldrelease/install-circleci
 
 # Read 2 arguments from the command line so we can debug this script.
 # Argument 1 is the release version. Defaults to releaser env variable.
@@ -18,7 +18,7 @@ CIRCLECI_CLI_HOST="https://circleci.com"
 circleci orb validate build/package/circleci/orb.yml || (echo "Unable to validate orb"; exit 1)
 
 # dev publish only, not production
-circleci orb publish build/package/circleci/orb.yml launchdarkly/ld-find-code-refs@dev:$RELEASE_VERSION --token $CIRCLECI_CLI_TOKEN --host $CIRCLECI_CLI_HOST
+#circleci orb publish build/package/circleci/orb.yml launchdarkly/ld-find-code-refs@dev:$RELEASE_VERSION --token $CIRCLECI_CLI_TOKEN --host $CIRCLECI_CLI_HOST
 
-# TODO: uncomment this once we have the circleci token in SSM.
-#circleci orb publish build/package/circleci/orb.yml launchdarkly/ld-find-code-refs@$RELEASE_VERSION --token $CIRCLECI_CLI_TOKEN --host $CIRCLECI_CLI_HOST
+# publish to production
+circleci orb publish build/package/circleci/orb.yml launchdarkly/ld-find-code-refs@$RELEASE_VERSION --token $CIRCLECI_CLI_TOKEN --host $CIRCLECI_CLI_HOST

--- a/.ldrelease/publish-circleci.sh
+++ b/.ldrelease/publish-circleci.sh
@@ -3,8 +3,7 @@
 # Run this in publish step after all version information have been updated.
 set -ev
 
-sudo apt install curl
-./.ldrelease/install-circleci
+.ldrelease/install-circleci.sh
 
 # Read 2 arguments from the command line so we can debug this script.
 # Argument 1 is the release version. Defaults to releaser env variable.

--- a/.ldrelease/publish.sh
+++ b/.ldrelease/publish.sh
@@ -4,6 +4,6 @@
 $(dirname $0)/run-publish-target.sh publish
 
 # TODO: publish to github actions, bitbucket and circleci marketplaces
-#./publish-github-actions-metadata.sh
-#./publish-bitbucket-metadata.sh
-#./publish-circleci.sh
+#$(dirname $0)/publish-github-actions-metadata.sh
+#$(dirname $0)/publish-bitbucket-metadata.sh
+#$(dirname $0)/publish-circleci.sh


### PR DESCRIPTION
We've got our github owner token finally! Yay! This ticket is to fix a few issues found when publishing to circleci orbs using the new token:

* Fix ldreleaser path to the install cli script
* Uncomment production publish step
* Comment dev publish step
* Fix paths to other marketplace publish scripts