### PR TITLE
Update integrations metadata

### DIFF
--- a/build/metadata/bitbucket/README.md
+++ b/build/metadata/bitbucket/README.md
@@ -8,7 +8,7 @@ Add the following snippet to the script section of your `bitbucket-pipelines.yml
 - pipe: - pipe: launchdarkly/ld-find-code-refs-pipe:x.x.x
   environment:
     LD_ACCESS_TOKEN: "<string>"
-    LD_PROJ_KEY: "<string>"
+    LD_PROJ_KEY: "<string>" # Required unless using 'projects' block in configuration file then it must be omitted.
     # LD_REPO_NAME: "<string>" # Optional.
     # LD_CONTEXT_LINES: "<integer>" # Optional.
     # LD_BASE_URI: "<string>" # Optional.
@@ -27,7 +27,7 @@ See [the configuration documentation](https://github.com/launchdarkly/ld-find-co
 | Variable                 | Usage |
 | --------------------------- | ----- |
 | LD_ACCESS_TOKEN (*)       | A LaunchDarkly personal access token with writer-level access, or access to the `code-reference-repository` [custom role](https://docs.launchdarkly.com/v2.0/docs/custom-roles) resource. Should be provided as a [secured repository variable](https://confluence.atlassian.com/bitbucket/variables-in-pipelines-794502608.html) to secure it. |
-| LD_PROJ_KEY (*)   | A LaunchDarkly project key. The pipewill search this project for code references in this project. |
+| LD_PROJ_KEY (*)   | A LaunchDarkly project key. The pipewill search this project for code references in this project. Cannot be combined with `projects` block in configuration file. |
 | LD_REPO_NAME | Sets the repository name for this project. This is useful if you have a single monorepo containing multiple YAML configurations, each of which maps to its own LD_PROJ_KEY. Each YAML configuration must have a unique LD_PROJ_KEY and LD_REPO_NAME combination so it displays correctly in the LaunchDarkly dashboard. Defaults to the current Bitbucket repository. |
 | LD_CONTEXT_LINES        | The number of context lines above and below a code reference for the flag parser to send to LaunchDarkly. If < 0, no source code will be sent to LaunchDarkly. If 0, only the lines containing flag references will be sent. If > 0, will send that number of context lines above and below the flag reference. A maximum of 5 context lines may be provided. Defaults to 2 |
 | LD_BASE_URI                 | Set the base URL of the LaunchDarkly server for this configuration. Defaults to https://app.launchdarkly.com |

--- a/build/metadata/github-actions/action.yml
+++ b/build/metadata/github-actions/action.yml
@@ -6,8 +6,8 @@ branding:
   color: gray-dark
 inputs:
   projKey:
-    description: 'Key of the LaunchDarkly project associated with this repository. Found under Account Settings -> Projects in the LaunchDarkly dashboard.'
-    required: true
+    description: 'Key of the LaunchDarkly project associated with this repository. Found under Account Settings -> Projects in the LaunchDarkly dashboard. Cannot be combined with `projects` block in configuration file.'
+    required: false
   accessToken:
     description: 'Token with write access to LaunchDarkly project.'
     required: true

--- a/build/package/circleci/orb.yml
+++ b/build/package/circleci/orb.yml
@@ -59,7 +59,7 @@ jobs:
         type: string
         default: "${LD_ACCESS_TOKEN}"
       proj_key:
-        description: LaunchDarkly project key. Found under Account Settings -> Projects in the LaunchDarkly dashboard.
+        description: LaunchDarkly project key. Found under Account Settings -> Projects in the LaunchDarkly dashboard. Cannot be combined with `projects` block in configuration file.
         type: string
       base_uri:
         description: Set the base URL of the LaunchDarkly server for this configuration. Only necessary if using a private instance of LaunchDarkly.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -59,7 +59,7 @@ Flags:
 
   -o, --outDir string              If provided, will output a csv file containing all code references for the project to this directory.
 
-  -p, --projKey string             LaunchDarkly project key. Found under Account Settings -> Projects in the LaunchDarkly dashboard.
+  -p, --projKey string             LaunchDarkly project key. Found under Account Settings -> Projects in the LaunchDarkly dashboard. Cannot be combined with `projects` block in configuration file.
 
   -r, --repoName string            Repository name. Will be displayed in LaunchDarkly. Case insensitive. Repo names must only contain letters, numbers, '.', '_' or '-'."
 


### PR DESCRIPTION
Add information that `projKey` is no longer required if using `projects` block.