### PR TITLE
Switch to use jitter with min/max

### DIFF
--- a/internal/ld/ld.go
+++ b/internal/ld/ld.go
@@ -82,8 +82,8 @@ func InitApiClient(options ApiOptions) ApiClient {
 	if options.RetryMax != nil && *options.RetryMax >= 0 {
 		client.RetryMax = *options.RetryMax
 	}
-	client.RetryWaitMin = 1000 * time.Millisecond
-	client.RetryWaitMax = 30000 * time.Millisecond
+	client.RetryWaitMin = 1 * time.Second
+	client.RetryWaitMax = 30 * time.Second
 	client.Backoff = retryablehttp.LinearJitterBackoff
 
 	return ApiClient{

--- a/internal/ld/ld.go
+++ b/internal/ld/ld.go
@@ -16,7 +16,9 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
+	"github.com/hashicorp/go-retryablehttp"
 	h "github.com/hashicorp/go-retryablehttp"
 	"github.com/olekukonko/tablewriter"
 
@@ -80,6 +82,10 @@ func InitApiClient(options ApiOptions) ApiClient {
 	if options.RetryMax != nil && *options.RetryMax >= 0 {
 		client.RetryMax = *options.RetryMax
 	}
+	client.RetryWaitMin = 1000 * time.Millisecond
+	client.RetryWaitMax = 30000 * time.Millisecond
+	client.Backoff = retryablehttp.LinearJitterBackoff
+
 	return ApiClient{
 		ldClient: ldapi.NewAPIClient(&ldapi.Configuration{
 			UserAgent: options.UserAgent,


### PR DESCRIPTION
The current retries, try with a timed exponential backoff. If a branch has multiple commits that finish at roughly the same time this will cause them to all POST at the same time and if it errors to keep retrying in sync. This will cause them to have more variation between attempts. We still perform server side validation that the highest sync time is what is used.