### PR TITLE
Use first project key in filename output

### DIFF
--- a/coderefs/coderefs.go
+++ b/coderefs/coderefs.go
@@ -121,7 +121,7 @@ func handleOutput(opts options.Options, matcher search.Matcher, branch ld.Branch
 	}
 
 	if outDir != "" {
-		outPath, err := branch.WriteToCSV(outDir, repoParams.Name, opts.Revision)
+		outPath, err := branch.WriteToCSV(outDir, projectKeys[0], repoParams.Name, opts.Revision)
 		if err != nil {
 			log.Error.Fatalf("error writing code references to csv: %s", err)
 		}

--- a/internal/ld/ld.go
+++ b/internal/ld/ld.go
@@ -462,7 +462,7 @@ func (b BranchRep) TotalHunkCount() int {
 	return count
 }
 
-func (b BranchRep) WriteToCSV(outDir, repo, sha string) (path string, err error) {
+func (b BranchRep) WriteToCSV(outDir, projKey, repo, sha string) (path string, err error) {
 	// Try to create a filename with a shortened sha, but if the sha is too short for some unexpected reason, use the branch name instead
 	var tag string
 	if len(sha) >= 7 {
@@ -475,7 +475,7 @@ func (b BranchRep) WriteToCSV(outDir, repo, sha string) (path string, err error)
 	if err != nil {
 		return "", fmt.Errorf("invalid outDir '%s': %w", outDir, err)
 	}
-	path = filepath.Join(absPath, fmt.Sprintf("coderefs_%s_%s.csv", repo, tag))
+	path = filepath.Join(absPath, fmt.Sprintf("coderefs_%s_%s_%s.csv", projKey, repo, tag))
 
 	f, err := os.Create(path)
 	if err != nil {


### PR DESCRIPTION
To perserve backwards compatibility we're using the 1st project key in the CSV filename output. If a user is still using `projKey` it is convert to the 1st and only project.