### PR TITLE
Enable Builds for arm64

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,6 +12,7 @@ builds:
     goarch:
       - 386
       - amd64
+      - arm64
 
     ignore:
       - goos: darwin

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Note: These commands pertain to the development of ld-find-code-refs.
 #       They are not intended for use by the end-users of this program.
 SHELL=/bin/bash
-GORELEASER_VERSION=v0.169.0
+GORELEASER_VERSION=v1.5.0
 
 build:
 	go build ./cmd/...


### PR DESCRIPTION
* Update GoReleaser version to support the new builds
* add build option for arm64