### PR TITLE
update to use go1.18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ defaults:
 jobs:
   go-test:
     docker:
-      - image: cimg/go:1.17.1
+      - image: cimg/go:1.18
         environment:
           <<: *environment
 
@@ -69,7 +69,7 @@ jobs:
 
   test-publish:
     docker:
-      - image: cimg/go:1.17.1
+      - image: cimg/go:1.18
     steps:
       - checkout
       - setup_remote_docker

--- a/.ldrelease/config.yml
+++ b/.ldrelease/config.yml
@@ -5,7 +5,7 @@ repo:
 
 jobs:
   - docker:
-      image: cimg/go:1.17.1
+      image: cimg/go:1.18
       copyGitHistory: true
     template:
       name: go

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/launchdarkly/ld-find-code-refs
 
-go 1.17
+go 1.18
 
 require (
 	github.com/go-git/go-git/v5 v5.4.2


### PR DESCRIPTION
Upgrade to the latest 1.18

> Last but not least, the expansion of Go 1.17’s register ABI calling convention to Apple M1, ARM64, and PowerPC64 architectures has resulted in up to a 20% increase in CPU speed in Go 1.18.

