### PR TITLE
Add additional debugging for extinction events

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -204,6 +204,7 @@ func (c Client) FindExtinctions(project options.Project, flags []string, matcher
 
 	ret := []ld.ExtinctionRep{}
 	for i, c := range commits[:len(commits)-1] {
+		log.Debug.Printf("Examining commit: %s", c.commit.Hash)
 		changes, err := commits[i+1].tree.Diff(c.tree)
 		if err != nil {
 			return nil, err
@@ -214,6 +215,7 @@ func (c Client) FindExtinctions(project options.Project, flags []string, matcher
 		}
 		for _, filePatch := range patch.FilePatches() {
 			fromFile, toFile := filePatch.Files()
+			log.Debug.Printf("Examining from file: %s and to file: %s", fromFile, toFile)
 			if project.Dir != "" && (toFile == nil || !strings.HasPrefix(toFile.Path(), project.Dir)) {
 				if fromFile != nil && !strings.HasPrefix(fromFile.Path(), project.Dir) {
 					continue
@@ -244,6 +246,7 @@ func (c Client) FindExtinctions(project options.Project, flags []string, matcher
 						ProjKey:  project.Key,
 						FlagKey:  flag,
 					})
+					log.Debug.Printf("Found extinct flag: %s in project: %s", flag, project.Key)
 				} else {
 					// this flag was not removed in the current commit, so check for it again in the next commit
 					nextFlags = append(nextFlags, flag)

--- a/internal/git/git_integration_test.go
+++ b/internal/git/git_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/launchdarkly/ld-find-code-refs/internal/ld"
+	"github.com/launchdarkly/ld-find-code-refs/internal/log"
 	"github.com/launchdarkly/ld-find-code-refs/options"
 	"github.com/stretchr/testify/require"
 
@@ -21,6 +22,11 @@ const (
 	flag2   = "flag2"
 	flag3   = "flag3"
 )
+
+func TestMain(m *testing.M) {
+	log.Init(true)
+	os.Exit(m.Run())
+}
 
 func setupRepo(t *testing.T) *git.Repository {
 	os.RemoveAll(repoDir)


### PR DESCRIPTION
Make it easier to find out why extinction searches are timing out for some github action runs.