### PR TITLE
update debug logging for extinctions

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -11,6 +11,7 @@ import (
 
 	git "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/format/diff"
 	object "github.com/go-git/go-git/v5/plumbing/object"
 
 	"github.com/launchdarkly/ld-find-code-refs/internal/ld"
@@ -249,6 +250,7 @@ func (c Client) FindExtinctions(project options.Project, flags []string, matcher
 		}
 		for _, filePatch := range patch.FilePatches() {
 			fromFile, toFile := filePatch.Files()
+			printDebugStatement(fromFile, toFile)
 			if project.Dir != "" && (toFile == nil || !strings.HasPrefix(toFile.Path(), project.Dir)) {
 				if fromFile != nil && !strings.HasPrefix(fromFile.Path(), project.Dir) {
 					continue
@@ -290,4 +292,15 @@ func (c Client) FindExtinctions(project options.Project, flags []string, matcher
 	}
 
 	return ret, err
+}
+
+func printDebugStatement(fromFile, toFile diff.File) {
+	fromPath, toPath := "FROM_PATH", "TO_PATH"
+	if fromFile != nil {
+		fromPath = fromFile.Path()
+	}
+	if toFile != nil {
+		toPath = toFile.Path()
+	}
+	log.Debug.Printf("Examining from file: %s and to file: %s", fromPath, toPath)
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -249,7 +249,6 @@ func (c Client) FindExtinctions(project options.Project, flags []string, matcher
 		}
 		for _, filePatch := range patch.FilePatches() {
 			fromFile, toFile := filePatch.Files()
-			log.Debug.Printf("Examining from file: %s and to file: %s", fromFile, toFile)
 			if project.Dir != "" && (toFile == nil || !strings.HasPrefix(toFile.Path(), project.Dir)) {
 				if fromFile != nil && !strings.HasPrefix(fromFile.Path(), project.Dir) {
 					continue


### PR DESCRIPTION
logs recently added had no valuable content

```
6 251 185 193 128 214 233 125 161 221 107] 0x14000288f00 map[] map[]}) {orb.yml %!s(filemode.FileMode=33188) ysC? ?:?$?p~?">?tf?@}}} and to file: &{{build/package/circleci/orb.yml %!s(*object.Tree=&{[{orb.yml 33188 [64 23 115 209 204 254 247 200 124 99 55 113 53 176 237 71 42 150 196 141]}] [224 246 88 39 167 159 99 193 176 41 71 112 93 77 209 61 202 31 4 0] 0x14000288f00 map[] map[]}) {orb.yml %!s(filemode.FileMode=33188) @s?????|c7q5??G*?č}}}
DEBUG: 2022/08/31 16:04:18 git.go:218: Examining from file: &{{internal/version/version.go %!s(*object.Tree=&{[{version.go 33188 [233 201 27 89 79 206 135 168 45 212 35 155 98 161 188 66 1 22 37 20]}] [36 24 226 95 157 198 87 139 32 65 59 105 63 121 222 190 129 27 210 36] 0x14000288f00 map[] map[]}) {version.go %!s(filemode.FileMode=33188) ??O·?-?#?b??B%}}} and to file: &{{internal/version/version.go %!s(*object.Tree=&{[{version.go 33188 [157 159 80 181 4 10 119 192 204 176 4 39 237 110 211 216 161 112 208 88]}] [35 235 31 235 179 139 138 198 145 146 116 221 52 125 158 145 212 236 96 136] 0x14000288f00 map[] map[]}) {version.go %!s(filemode.FileMode=33188) ??P?
w?̰'?n?ءp?X}}}
DEBUG: 2022/08/31 16:04:18 git.go:207: Examining commit: 54d86ed2d174c693e5040c25e9f4ae9deb6cd982
DEBUG: 2022/08/31 16:04:18 git.go:218: Examining from file: &{{CHANGELOG.md %!s(*object.Tree=&{[{.circleci 16384 [252 123 219 17 40 50 94 220 134 83 200 225 4 201 28 180 203 96 123 28]} {.github 16384 [191 0 40 59 6 139 227 227 90 68 132 233 252 176 216 23 19 101 1 113]} {.gitignore 33188 [193 185 244 30 108 95 153 161 220 135 21 132 26 38 32 27 15 3 122 224]} {.golangci.yml 33188 [178 49 81 218 91 214 70 30 53 32 129 150 86 245 32 63 172 25 137 73]} {.goreleaser.yml 33188 [213 34 4 183 180 151 65 98 206 152 126 217 47 96 12 0 109 74 99 8]} {.ldrelease 16384 [6 128 242 101 246 211 254 89 84 25 82 131 80 91 0 90 88 30 104 116]} {.pre-commit-config.yaml 33188 [103 23 255 253 46 8 159 218 26 178 111 76 65 177 168 56 105 217 229 21]} {CHANGELOG.md 33188 [104 134 220 42 65 239 86 253 159 128 185 89 194 11 4 186 112 220 149 101]} {CODEOWNERS 33188 [187 56 71 96 211 5 62 46 67 239 128 2 51 237 96 5 210 139 111 71]} {Dockerfile.bitbucket 33188 [130 219 159 221 233 128 140 202 198 151 147 157 50 81 152 252 80 43 34 26]} {Dockerfile.github 33188 [236 101 209 74 182 127 106 171 87 130 247 254 58 202 206 228 156 22 67 212]} {LICENSE.txt 33188 [117 16 7 29 155 30 88 166 92 155 53 20 175 71 79 25 180 172 40 168]} {Makefile 33188 [17 187 170 80 77 15 23 113 122 110 117 131 104 15 145 13 36 136 147 203]} {README.md 33188 [19 212 96 64 193 153 207 137 234 177 5 67 165 125 129 24 221 190 183 118]} {aliases 16384 [67 190 21 215 247 206 45 229 220 173 254 215 61 111 111 36 175 43 9 135]} {build 16384 [15 94 198 88 95 139 30 11 188 18 243 174 6 44 251 68 35 13 115 2]} {cmd 16384 [147 234 6 227 54 123 119 230 139 101 132 19 118 232 26 104 174 37 47 78]} {coderefs 16384 [66 82 210 19 18 101 157 36 138 112 214 34 64 13 240 59 45 246 21 58]} {docs 16384 [4 105 234 220 82 80 94 103 30 238 73 28 201 73 217 208 240 254 245 89]} {flags 16384 [81 53 136 25 152 255 171 74 176 81 251 155 208 248 29 239 135 240 21 139]} {go.mod 33188 [199 48 109 120 197 74 113 19 18 196 160 178 27 197 212 85 28 42 240 72]} {go.sum 33188 [159 245 38 220 152 133 18 5 117 153 218 179 98 70 89 107 224 211 248 250]} {internal 16384 [182 158 15 193 119 137 187 14 218 69 164 3 91 196 245 68 73 128 107 75]} {options 16384 [126 225 231 47 138 142 186 48 224 161 169 200 139 106 17 252 67 62 239 235]} {search 16384 [229 194 84 128 46 26 29 169 255 100 114 31 194 221 51 184 180 63 122 70]}] [252 89 80 140 143 63 102 201 99 152 84 154 135 250 180 46 109 230 62 128] 0x14000288f00 map[.
```

new logs

```
DEBUG: 2022/08/31 16:22:55 git.go:271: Examining from file: internal/ld/ld_test.go and to file: internal/ld/ld_test.go
DEBUG: 2022/08/31 16:22:55 git.go:271: Examining from file: options/flags.go and to file: options/flags.go
```