### PR TITLE
Add a missing backslash

### DIFF
--- a/build/package/circleci/orb.yml
+++ b/build/package/circleci/orb.yml
@@ -131,5 +131,5 @@ jobs:
               --hunkUrlTemplate=<< parameters.hunk_url_template >> \
               --repoName=${CIRCLE_PROJECT_REPONAME} \
               --updateSequenceId=${CIRCLE_BUILD_NUM} \
-              --dir=/repo
+              --dir=/repo \
               --userAgent="circle-ci"


### PR DESCRIPTION
The commit adding --userAgent argument broke the CircleCI orb due to a missing backslash