### PR TITLE
Log when no files match alias file pattern

### DIFF
--- a/aliases/alias_test.go
+++ b/aliases/alias_test.go
@@ -5,8 +5,10 @@ import (
 	"os"
 	"testing"
 
-	o "github.com/launchdarkly/ld-find-code-refs/options"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/launchdarkly/ld-find-code-refs/internal/log"
+	o "github.com/launchdarkly/ld-find-code-refs/options"
 )
 
 var allNamingConventions = []o.Alias{
@@ -26,6 +28,11 @@ const (
 	testFlagAliasKey = "AnyKind.of_key"
 	testWildFlagKey  = "wildFlag"
 )
+
+func TestMain(m *testing.M) {
+	log.Init(true)
+	os.Exit(m.Run())
+}
 
 func Test_GenerateAliases(t *testing.T) {
 	specs := []struct {
@@ -138,8 +145,8 @@ func Test_processFileContent(t *testing.T) {
 				},
 			},
 			dir:     "dirDoesNotExist",
-			want:    nil,
-			wantErr: true,
+			want:    map[string][]byte{},
+			wantErr: false,
 		},
 		{
 			name: "Non-existent file",
@@ -150,8 +157,8 @@ func Test_processFileContent(t *testing.T) {
 				},
 			},
 			dir:     tmpDir,
-			want:    nil,
-			wantErr: true,
+			want:    map[string][]byte{},
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {

--- a/aliases/alias_test.go
+++ b/aliases/alias_test.go
@@ -145,7 +145,7 @@ func Test_processFileContent(t *testing.T) {
 				},
 			},
 			dir:     "dirDoesNotExist",
-			want:    map[string][]byte{},
+			want:    emptyMap,
 			wantErr: false,
 		},
 		{
@@ -157,7 +157,7 @@ func Test_processFileContent(t *testing.T) {
 				},
 			},
 			dir:     tmpDir,
-			want:    map[string][]byte{},
+			want:    emptyMap,
 			wantErr: false,
 		},
 	}

--- a/search/matcher_test.go
+++ b/search/matcher_test.go
@@ -10,7 +10,7 @@ import (
 func Test_buildFlagPatterns(t *testing.T) {
 	testFlagKey := "testflag"
 	patterns := buildElementPatterns([]string{testFlagKey}, defaultDelims)
-	want := map[string][]string{"testflag": []string{"\"testflag\"", "\"testflag'", "\"testflag`", "'testflag\"", "'testflag'", "'testflag`", "`testflag\"", "`testflag'", "`testflag`"}}
+	want := map[string][]string{"testflag": {"\"testflag\"", "\"testflag'", "\"testflag`", "'testflag\"", "'testflag'", "'testflag`", "`testflag\"", "`testflag'", "`testflag`"}}
 	require.Equal(t, want, patterns)
 }
 


### PR DESCRIPTION
[Starting in v2.4.0](https://github.com/launchdarkly/ld-find-code-refs/pull/173), we throw an error if an alias filepattern glob has no matches. This reverts that behavior and we now just log when there are no matching files.