### PR TITLE
Temporary revert "Log when no files match alias file pattern"

### DIFF
--- a/aliases/alias.go
+++ b/aliases/alias.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/iancoleman/strcase"
 	"github.com/launchdarkly/ld-find-code-refs/internal/helpers"
-	"github.com/launchdarkly/ld-find-code-refs/internal/log"
 	"github.com/launchdarkly/ld-find-code-refs/internal/validation"
 	"github.com/launchdarkly/ld-find-code-refs/options"
 )
@@ -28,10 +27,7 @@ func GenerateAliases(flags []string, aliases []options.Alias, dir string) (map[s
 
 	ret := make(map[string][]string, len(flags))
 	for _, flag := range flags {
-		for i, a := range aliases {
-			if a.Name == "" {
-				a.Name = strconv.Itoa(i)
-			}
+		for _, a := range aliases {
 			flagAliases, err := generateAlias(a, flag, dir, allFileContents)
 			if err != nil {
 				return nil, err
@@ -45,7 +41,6 @@ func GenerateAliases(flags []string, aliases []options.Alias, dir string) (map[s
 
 func generateAlias(a options.Alias, flag, dir string, allFileContents map[string][]byte) ([]string, error) {
 	ret := []string{}
-	aliasId := a.Name
 	switch a.Type.Canonical() {
 	case options.Literal:
 		ret = a.Flags[flag]
@@ -68,7 +63,7 @@ func generateAlias(a options.Alias, flag, dir string, allFileContents map[string
 			absGlob := filepath.Join(dir, path)
 			matches, err := filepath.Glob(absGlob)
 			if err != nil {
-				return nil, fmt.Errorf("filepattern '%s': could not process path glob '%s'", aliasId, absGlob)
+				return nil, fmt.Errorf("could not process path glob '%s'", absGlob)
 			}
 			for _, match := range matches {
 				pathFileContents := allFileContents[match]
@@ -106,11 +101,11 @@ func generateAlias(a options.Alias, flag, dir string, allFileContents map[string
 		cmd.Dir = dir
 		stdout, err := cmd.Output()
 		if err != nil {
-			return nil, fmt.Errorf("filepattern '%s': failed to execute alias command: %w", aliasId, err)
+			return nil, fmt.Errorf("failed to execute alias command: %w", err)
 		}
 		err = json.Unmarshal(stdout, &ret)
 		if err != nil {
-			return nil, fmt.Errorf("filepattern '%s': could not unmarshal json output of alias command: %w", aliasId, err)
+			return nil, fmt.Errorf("could not unmarshal json output of alias command: %w", err)
 		}
 	}
 
@@ -134,11 +129,8 @@ func processFileContent(aliases []options.Alias, dir string) (map[string][]byte,
 		for _, glob := range a.Paths {
 			absGlob := filepath.Join(dir, glob)
 			matches, err := filepath.Glob(absGlob)
-			if err != nil {
+			if matches == nil || err != nil {
 				return nil, fmt.Errorf("filepattern '%s': could not process path glob '%s'", aliasId, absGlob)
-			}
-			if matches == nil {
-				log.Info.Printf("filepattern '%s': no matching files found for alias path glob '%s'", aliasId, absGlob)
 			}
 			paths = append(paths, matches...)
 		}

--- a/aliases/alias_test.go
+++ b/aliases/alias_test.go
@@ -5,10 +5,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
-	"github.com/launchdarkly/ld-find-code-refs/internal/log"
 	o "github.com/launchdarkly/ld-find-code-refs/options"
+	"github.com/stretchr/testify/assert"
 )
 
 var allNamingConventions = []o.Alias{
@@ -28,11 +26,6 @@ const (
 	testFlagAliasKey = "AnyKind.of_key"
 	testWildFlagKey  = "wildFlag"
 )
-
-func TestMain(m *testing.M) {
-	log.Init(true)
-	os.Exit(m.Run())
-}
 
 func Test_GenerateAliases(t *testing.T) {
 	specs := []struct {
@@ -145,8 +138,8 @@ func Test_processFileContent(t *testing.T) {
 				},
 			},
 			dir:     "dirDoesNotExist",
-			want:    emptyMap,
-			wantErr: false,
+			want:    nil,
+			wantErr: true,
 		},
 		{
 			name: "Non-existent file",
@@ -157,8 +150,8 @@ func Test_processFileContent(t *testing.T) {
 				},
 			},
 			dir:     tmpDir,
-			want:    emptyMap,
-			wantErr: false,
+			want:    nil,
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {

--- a/search/matcher_test.go
+++ b/search/matcher_test.go
@@ -10,7 +10,7 @@ import (
 func Test_buildFlagPatterns(t *testing.T) {
 	testFlagKey := "testflag"
 	patterns := buildElementPatterns([]string{testFlagKey}, defaultDelims)
-	want := map[string][]string{"testflag": {"\"testflag\"", "\"testflag'", "\"testflag`", "'testflag\"", "'testflag'", "'testflag`", "`testflag\"", "`testflag'", "`testflag`"}}
+	want := map[string][]string{"testflag": []string{"\"testflag\"", "\"testflag'", "\"testflag`", "'testflag\"", "'testflag'", "'testflag`", "`testflag\"", "`testflag'", "`testflag`"}}
 	require.Equal(t, want, patterns)
 }
 


### PR DESCRIPTION
Reverts launchdarkly/ld-find-code-refs#271 so we can attempt a v2.6.3 release