### PR TITLE
lock API version

### DIFF
--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -31,6 +31,7 @@ func MakeTimestamp() int64 {
 func FatalServiceError(err error, ignoreServiceErrors bool) {
 	if ld.IsTransient(err) {
 		if ignoreServiceErrors {
+			log.Error.Fatal(fmt.Errorf("%w\n Ignoring error and exiting", err))
 			os.Exit(0)
 		}
 		err = fmt.Errorf("%w\n Add the --ignoreServiceErrors flag to ignore this error", err)

--- a/internal/ld/ld.go
+++ b/internal/ld/ld.go
@@ -42,8 +42,10 @@ type ApiOptions struct {
 }
 
 const (
-	v2ApiPath = "/api/v2"
-	reposPath = v2ApiPath + "/code-refs/repositories"
+	apiVersion       = "20191212"
+	apiVersionHeader = "LD-API-Version"
+	v2ApiPath        = "/api/v2"
+	reposPath        = v2ApiPath + "/code-refs/repositories"
 )
 
 type ConfigurationError struct {
@@ -91,6 +93,9 @@ func InitApiClient(options ApiOptions) ApiClient {
 			Servers: []ldapi.ServerConfiguration{{
 				URL: options.BaseUri,
 			}},
+			DefaultHeader: map[string]string{
+				apiVersionHeader: apiVersion,
+			},
 		}),
 		httpClient: client,
 		Options:    options,
@@ -356,6 +361,7 @@ type ldErrorResponse struct {
 
 func (c ApiClient) do(req *h.Request) (*http.Response, error) {
 	req.Header.Set("Authorization", c.Options.ApiKey)
+	req.Header.Set(apiVersionHeader, apiVersion)
 	req.Header.Set("User-Agent", c.Options.UserAgent)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Content-Length", strconv.FormatInt(req.ContentLength, 10))

--- a/internal/ld/ld.go
+++ b/internal/ld/ld.go
@@ -42,7 +42,7 @@ type ApiOptions struct {
 }
 
 const (
-	apiVersion       = "20191212"
+	apiVersion       = "20210729"
 	apiVersionHeader = "LD-API-Version"
 	v2ApiPath        = "/api/v2"
 	reposPath        = v2ApiPath + "/code-refs/repositories"


### PR DESCRIPTION
workflows with newer tokens set up were failing