### PR TITLE
[sc-157321] Allow designating `dir` in github action

### DIFF
--- a/build/metadata/github-actions/README.md
+++ b/build/metadata/github-actions/README.md
@@ -92,9 +92,9 @@ If the action fails, there may be a problem with your configuration. To investig
 
 All [command line flags](https://github.com/launchdarkly/ld-find-code-refs/blob/main/docs/CONFIGURATION.md#command-line) are available as environment variables following the "upper snake case" format, with a prefix of `LD_`. For example, the command line option `dir` may be set as an environment variable using `LD_DIR`.
 
-For example, if your action checks out multiple repositories you may override the default `dir` which is `GITHUB_WORKSPACE`.
+The default `dir` is `GITHUB_WORKSPACE`. This is the default working directory on the runner for steps and the default location of your repository when using the checkout action, for example, `/home/runner/work/my-repo-name/my-repo-name`.
 
-> GITHUB_WORKSPACE - The default working directory on the runner for steps, and the default location of your repository when using the checkout action. For example, /home/runner/work/my-repo-name/my-repo-name.
+If your action checks out multiple repositories, override the default `dir`.
 
 
 ```yaml

--- a/build/metadata/github-actions/README.md
+++ b/build/metadata/github-actions/README.md
@@ -87,3 +87,37 @@ If the action fails, there may be a problem with your configuration. To investig
 | projKey | Key of the LaunchDarkly project associated with this repository. Found under Account Settings -> Projects in the LaunchDarkly dashboard. Cannot be combined with `projects` block in configuration file. | `false` |  |
 | repoName | The repository name. Defaults to the current GitHub repository. | `false` |  |
 <!-- action-docs-inputs -->
+
+# Additional inputs
+
+All [command line flags](https://github.com/launchdarkly/ld-find-code-refs/blob/main/docs/CONFIGURATION.md#command-line) are available as environment variables following the "upper snake case" format, with a prefix of `LD_`. For example, the command line option `dir` may be set as an environment variable.
+
+For example, if your action checks out multiple repositories you may override the default `dir` which is `GITHUB_WORKSPACE`.
+
+> GITHUB_WORKSPACE - The default working directory on the runner for steps, and the default location of your repository when using the checkout action. For example, /home/runner/work/my-repo-name/my-repo-name.
+
+
+```yaml
+jobs:
+  launchDarklyCodeReferences:
+    name: LaunchDarkly Code References
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repo to scan
+      uses: actions/checkout@v3
+      with:
+        repository: launchdarkly/SupportService
+        path: repo-to-scan
+    - name: Checkout current repo
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 10
+        path: main
+    - name: LaunchDarkly Code References
+      uses: launchdarkly/find-code-references@v2.7.0
+      with:
+        accessToken: ${{ secrets.LD_ACCESS_TOKEN }}
+        projKey: LD_PROJECT_KEY
+      env:
+        LD_DIR: "${{ github.workspace}}/repo-to-scan"
+```

--- a/build/metadata/github-actions/README.md
+++ b/build/metadata/github-actions/README.md
@@ -119,5 +119,5 @@ jobs:
         accessToken: ${{ secrets.LD_ACCESS_TOKEN }}
         projKey: LD_PROJECT_KEY
       env:
-        LD_DIR: "${{ github.workspace}}/repo-to-scan"
+        LD_DIR: "${{ github.workspace }}/repo-to-scan"
 ```

--- a/build/metadata/github-actions/README.md
+++ b/build/metadata/github-actions/README.md
@@ -90,7 +90,7 @@ If the action fails, there may be a problem with your configuration. To investig
 
 # Additional inputs
 
-All [command line flags](https://github.com/launchdarkly/ld-find-code-refs/blob/main/docs/CONFIGURATION.md#command-line) are available as environment variables following the "upper snake case" format, with a prefix of `LD_`. For example, the command line option `dir` may be set as an environment variable.
+All [command line flags](https://github.com/launchdarkly/ld-find-code-refs/blob/main/docs/CONFIGURATION.md#command-line) are available as environment variables following the "upper snake case" format, with a prefix of `LD_`. For example, the command line option `dir` may be set as an environment variable using `LD_DIR`.
 
 For example, if your action checks out multiple repositories you may override the default `dir` which is `GITHUB_WORKSPACE`.
 

--- a/options/options.go
+++ b/options/options.go
@@ -154,9 +154,13 @@ func GetWrapperOptions(dir string, merge func(Options) (Options, error)) (Option
 	if err != nil {
 		return Options{}, err
 	}
-	err = flags.Set("dir", dir)
-	if err != nil {
-		return Options{}, err
+	// if dir is set, it means that it was
+	// overridden with `LD_DIR` environment variable
+	if d, _ := flags.GetString("dir"); d == "" {
+		err = flags.Set("dir", dir)
+		if err != nil {
+			return Options{}, err
+		}
 	}
 
 	err = InitYAML()


### PR DESCRIPTION
This is completely optional, but is useful if someone checks out multiple repos in their action.

For example, this [git-gatsby workflow](https://github.com/launchdarkly/git-gatsby/commit/4b59a0a37109bd26aa55bc0822bb571b5bdfd5bb) used to check out multiple repos internal repos

--

Dev notes

this must use `env` override and not github action input because of how env variable is used to find the configuration file etc.

