### PR TITLE
Update Bitbucket pipe metadata

### DIFF
--- a/build/metadata/bitbucket/README.md
+++ b/build/metadata/bitbucket/README.md
@@ -14,7 +14,6 @@ Add the following snippet to the script section of your `bitbucket-pipelines.yml
     # LD_BASE_URI: "<string>" # Optional.
     # LD_DEBUG: "<boolean>" # Optional.
     # LD_DEFAULT_BRANCH: "<string>" # Optional.
-    # LD_DELIMITERS "<string>" # Optional.
     # LD_IGNORE_SERVICE_ERRORS "<boolean>" # Optional.
     # LD_LOOKBACK "<integer>" # Optional.
     # LD_ALLOW_TAGS "<boolean>" #Optional.
@@ -27,7 +26,7 @@ See [the configuration documentation](https://github.com/launchdarkly/ld-find-co
 | Variable                 | Usage |
 | --------------------------- | ----- |
 | LD_ACCESS_TOKEN (*)       | A LaunchDarkly personal access token with writer-level access, or access to the `code-reference-repository` [custom role](https://docs.launchdarkly.com/v2.0/docs/custom-roles) resource. Should be provided as a [secured repository variable](https://confluence.atlassian.com/bitbucket/variables-in-pipelines-794502608.html) to secure it. |
-| LD_PROJ_KEY (*)   | A LaunchDarkly project key. The pipewill search this project for code references in this project. Cannot be combined with `projects` block in configuration file. |
+| LD_PROJ_KEY (**)   | A LaunchDarkly project key. The pipe will search this project for code references in this project. Cannot be combined with `projects` block in configuration file. |
 | LD_REPO_NAME | The repository name. Defaults to the current Bitbucket repository. |
 | LD_CONTEXT_LINES        | The number of context lines above and below a code reference for the flag parser to send to LaunchDarkly. If < 0, no source code will be sent to LaunchDarkly. If 0, only the lines containing flag references will be sent. If > 0, will send that number of context lines above and below the flag reference. A maximum of 5 context lines may be provided. Default: `2` |
 | LD_BASE_URI                 | Set the base URL of the LaunchDarkly server for this configuration. Defaults to https://app.launchdarkly.com |

--- a/build/metadata/bitbucket/README.md
+++ b/build/metadata/bitbucket/README.md
@@ -26,7 +26,7 @@ See [the configuration documentation](https://github.com/launchdarkly/ld-find-co
 | Variable                 | Usage |
 | --------------------------- | ----- |
 | LD_ACCESS_TOKEN (*)       | A LaunchDarkly personal access token with writer-level access, or access to the `code-reference-repository` [custom role](https://docs.launchdarkly.com/v2.0/docs/custom-roles) resource. Should be provided as a [secured repository variable](https://confluence.atlassian.com/bitbucket/variables-in-pipelines-794502608.html) to secure it. |
-| LD_PROJ_KEY (**)   | A LaunchDarkly project key. The pipe will search this project for code references in this project. Cannot be combined with `projects` block in configuration file. |
+| LD_PROJ_KEY   | A LaunchDarkly project key. The pipe will search this project for code references in this project. Cannot be combined with `projects` block in configuration file. |
 | LD_REPO_NAME | The repository name. Defaults to the current Bitbucket repository. |
 | LD_CONTEXT_LINES        | The number of context lines above and below a code reference for the flag parser to send to LaunchDarkly. If < 0, no source code will be sent to LaunchDarkly. If 0, only the lines containing flag references will be sent. If > 0, will send that number of context lines above and below the flag reference. A maximum of 5 context lines may be provided. Default: `2` |
 | LD_BASE_URI                 | Set the base URL of the LaunchDarkly server for this configuration. Defaults to https://app.launchdarkly.com |

--- a/build/metadata/bitbucket/pipe.yml
+++ b/build/metadata/bitbucket/pipe.yml
@@ -4,8 +4,6 @@ category: Feature flagging
 description: Job for finding and sending feature flag code references to LaunchDarkly
 repository: https://bitbucket.org/launchdarkly/ld-find-code-refs-pipe
 variables:
-  - name: LD_ACCESS_TOKEN
-  - name: LD_PROJ_KEY # Required unless using 'projects' block in configuration file then it must be omitted.
   - name: LD_REPO_NAME
     default: '$BITBUCKET_REPO_SLUG'
   - name: LD_CONTEXT_LINES
@@ -14,7 +12,6 @@ variables:
     default: 'https://app.launchdarkly.com'
   - name: LD_DEFAULT_BRANCH
     default: main
-  - name: LD_DELIMITERS
   - name: LD_IGNORE_SERVICE_ERRORS
     default: 'false'
   - name: LD_LOOKBACK


### PR DESCRIPTION
Address additional feedback from [bitbucket team](https://bitbucket.org/bitbucketpipelines/official-pipes/pull-requests/519/update-launchdarkly-pipe#comment-345449796)

- remove env variables without default values from pipe
- `LD_DELIMITERS` was deprecated some time again, remove it
- `LD_PROJ_KEY` not required 100% of the time