### PR TITLE
update owners : docs-reviewers --> squad-docs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,7 +3,7 @@
 * @launchdarkly/squad-flag-lifecycle
 
 # Documentation
-*.md @launchdarkly/docs-reviewers
+*.md @launchdarkly/squad-docs
 
 # Change log is updated by release bot
 CHANGELOG.md @launchdarkly/squad-flag-lifecycle


### PR DESCRIPTION
[SC-177641](https://app.shortcut.com/launchdarkly/story/177641/update-codeowners-based-on-github-team-name-change)

Tech Ops & Security (@jboyle-ld) are updating team names and permissions in GitHub. We've been switched from "docs-reviewers" to "squad-docs" so we need to update codeowners so that we're still automatically added as reviewers appropriately.