### PR TITLE
migrate deprecated ioutil pkg functions

### DIFF
--- a/aliases/alias.go
+++ b/aliases/alias.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
@@ -156,7 +156,7 @@ func processFileContent(aliases []options.Alias, dir string) (map[string][]byte,
 				return nil, fmt.Errorf("filepattern '%s': could not find file at path '%s'", aliasId, path)
 			}
 			/* #nosec */
-			data, err := ioutil.ReadFile(path)
+			data, err := os.ReadFile(path)
 			if err != nil {
 				return nil, fmt.Errorf("filepattern '%s': could not process file at path '%s': %v", aliasId, path, err)
 			}

--- a/aliases/alias_test.go
+++ b/aliases/alias_test.go
@@ -1,7 +1,6 @@
 package aliases
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -108,11 +107,11 @@ func Test_GenerateAliases(t *testing.T) {
 }
 
 func Test_processFileContent(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "")
+	tmpDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		panic(err)
 	}
-	f, err := ioutil.TempFile(tmpDir, "testalias")
+	f, err := os.MkdirTemp(tmpDir, "testalias")
 	if err != nil {
 		panic(err)
 	}
@@ -130,7 +129,7 @@ func Test_processFileContent(t *testing.T) {
 			name: "Existing directory and file",
 			aliases: []o.Alias{
 				{
-					Paths: []string{f.Name()},
+					Paths: []string{f},
 				},
 			},
 			dir:     tmpDir,

--- a/build/package/github-actions/github-actions.go
+++ b/build/package/github-actions/github-actions.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"regexp"
 	"strings"
@@ -104,7 +104,7 @@ func parseEvent(path string) (*Event, error) {
 		return nil, err
 	}
 
-	eventJsonBytes, err := ioutil.ReadAll(eventJsonFile)
+	eventJsonBytes, err := io.ReadAll(eventJsonFile)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/ld/ld.go
+++ b/internal/ld/ld.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -184,7 +184,7 @@ func (c ApiClient) getCodeReferenceRepository(name string) (*RepoRep, error) {
 		return nil, err
 	}
 
-	resBytes, err := ioutil.ReadAll(res.Body)
+	resBytes, err := io.ReadAll(res.Body)
 	if res != nil {
 		defer res.Body.Close()
 	}
@@ -210,7 +210,7 @@ func (c ApiClient) GetCodeReferenceRepositoryBranches(repoName string) ([]Branch
 		return nil, err
 	}
 
-	resBytes, err := ioutil.ReadAll(res.Body)
+	resBytes, err := io.ReadAll(res.Body)
 	if res != nil {
 		defer res.Body.Close()
 	}
@@ -375,7 +375,7 @@ func (c ApiClient) do(req *h.Request) (*http.Response, error) {
 	case http.StatusOK, http.StatusCreated, http.StatusNoContent:
 		return res, nil
 	default:
-		resBytes, err := ioutil.ReadAll(res.Body)
+		resBytes, err := io.ReadAll(res.Body)
 		if res != nil {
 			defer res.Body.Close()
 		}

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -1,7 +1,7 @@
 package log
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 )
@@ -16,7 +16,7 @@ var (
 
 // Init overrides the default loggers that write to stdout
 func Init(debug bool) {
-	debugHandle := ioutil.Discard
+	debugHandle := io.Discard
 	if debug {
 		debugHandle = os.Stdout
 	}


### PR DESCRIPTION
this package has been deprecated since Go 1.16 and started throwing lint errors.