### PR TITLE
CircleCI: make sure $BASH_ENV exists

### DIFF
--- a/build/package/circleci/orb.yml
+++ b/build/package/circleci/orb.yml
@@ -115,7 +115,8 @@ jobs:
       - run:
           name: Find flag references
           command: |
-            source $BASH_ENV || true
+            touch $BASH_ENV
+            source $BASH_ENV
             ld-find-code-refs \
               --debug="<< parameters.debug >>" \
               --accessToken="<< parameters.access_token >>" \


### PR DESCRIPTION
Fixes https://github.com/launchdarkly/ld-find-code-refs/issues/322

https://support.circleci.com/hc/en-us/articles/360048353271-Accessing-BASH-ENV-Results-in-No-such-file-or-directory-