### PR TITLE
Use Aho-Corasick implementation to speed up searching for extinctions

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -257,7 +257,7 @@ func (c Client) FindExtinctions(project options.Project, flags []string, matcher
 		}
 
 		nextFlags := make([]string, 0, len(flags))
-		flagMap := make(map[string]int, 0)
+		flagMap := make(map[string]int, len(flags))
 		for _, flag := range flags {
 			flagMap[flag] = 0
 		}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -269,9 +269,10 @@ func (c Client) FindExtinctions(project options.Project, flags []string, matcher
 
 			for _, chunk := range filePatch.Chunks() {
 				delta := 0
-				if chunk.Type() == diff.Delete {
+				switch chunk.Type() {
+				case diff.Delete:
 					delta = 1
-				} else if chunk.Type() == diff.Add {
+				case diff.Add:
 					delta = -1
 				}
 				if delta != 0 {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -250,12 +250,10 @@ func (c Client) FindExtinctions(project options.Project, flags []string, matcher
 		}
 
 		// get matcher for project
-		var elementMatcher search.ElementMatcher
-		for _, element := range matcher.Elements {
-			if element.ProjKey == project.Key {
-				elementMatcher = element
-				break
-			}
+		elementMatcher := matcher.GetProjectElementMatcher(project.Key)
+		if elementMatcher == nil {
+			// This is actually a huge issue if it happens
+			panic(fmt.Sprintf("Matcher for project (%s) not found", project.Key))
 		}
 
 		nextFlags := make([]string, 0, len(flags))

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -271,10 +271,10 @@ func (c Client) FindExtinctions(project options.Project, flags []string, matcher
 
 			for _, chunk := range filePatch.Chunks() {
 				delta := 0
-				if chunk.Type() == diff.Add {
-					delta = -1
-				} else if chunk.Type() == diff.Delete {
+				if chunk.Type() == diff.Delete {
 					delta = 1
+				} else if chunk.Type() == diff.Add {
+					delta = -1
 				}
 				if delta != 0 {
 					for _, line := range strings.Split(chunk.Content(), "\n") {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -274,7 +274,7 @@ func (c Client) FindExtinctions(project options.Project, flags []string, matcher
 				if delta != 0 {
 					for _, el := range element.FindMatches(patchLine) {
 						if _, ok := flagMap[el]; ok {
-							flagMap[el] = delta
+							flagMap[el] += delta
 						}
 					}
 				}

--- a/search/matcher.go
+++ b/search/matcher.go
@@ -127,6 +127,17 @@ func (m Matcher) MatchElement(line, element string) bool {
 	return false
 }
 
+func (m Matcher) GetProjectElementMatcher(projectKey string) *ElementMatcher {
+	var elementMatcher ElementMatcher
+	for _, element := range m.Elements {
+		if element.ProjKey == projectKey {
+			elementMatcher = element
+			break
+		}
+	}
+	return &elementMatcher
+}
+
 func (m Matcher) FindAliases(line, element string) []string {
 	matches := make([]string, 0)
 	for _, em := range m.Elements {


### PR DESCRIPTION
1. This applies [Aho-Corasick algorithm used elsewhere](https://github.com/launchdarkly/ld-find-code-refs/pull/174) to scanning extinctions
2. It also changes extinction scanning so that it's _per file_ (so it can use the right matcher when monorepo is set up) instead of scanning the entire patch at once.


--

More context -

We have encountered a lot of slow extinctions runs that takes code refs scanning from 1-2 minutes to much longer.
One reason for this was a bug we introduced in 2.5.0, but even with the behavior restored, extinction checking can take a really long time and we often advise customer to set a low `lookback` (default is 10) to make runs faster.

This should dramatically speed up extinction checks and make code refs work better out of the box.

--

so fast 😍 


from this...


```
INFO: 2023/02/16 15:07:36 coderefs.go:182: checking if 1845 flags without references were removed in the last 10
...
INFO: 2023/02/16 15:09:08 coderefs.go:187: found 0 removed flags
```

to this

```
INFO: 2023/02/16 14:41:32 coderefs.go:182: checking if 1845 flags without references were removed in the last 10 commits for project: default
...
INFO: 2023/02/16 14:41:33 coderefs.go:187: found 0 removed flags
```