### PR TITLE
fix: failed to find tag name for annotated tags

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -124,10 +124,11 @@ func (c *Client) tagName() (name string, err error) {
 	}
 
 	if err := iter.ForEach(func(ref *plumbing.Reference) error {
+		// Check if ref is an annotated tag
 		obj, err := repo.TagObject(ref.Hash())
 		if err != nil {
 			if errors.Is(err, plumbing.ErrObjectNotFound) {
-				// Lightweight tag
+				// Ref is lightweight tag
 				if head.Hash() == ref.Hash() {
 					name = ref.Name().Short()
 					iter.Close()
@@ -136,7 +137,7 @@ func (c *Client) tagName() (name string, err error) {
 			}
 			return err
 		}
-		// Annotated tag
+		// Annotated tag target is commit hash
 		if head.Hash() == obj.Target {
 			name = obj.Name
 			iter.Close()

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -131,8 +131,8 @@ func (c *Client) tagName() (name string, err error) {
 				if head.Hash() == ref.Hash() {
 					name = ref.Name().Short()
 					iter.Close()
-					return nil
 				}
+				return nil
 			}
 			return err
 		}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -137,7 +137,10 @@ func (c *Client) tagName() (name string, err error) {
 			}
 			return err
 		}
-		// Annotated tag target is commit hash
+		// Annotated tag target should be commit
+		if obj.TargetType != plumbing.CommitObject {
+			return nil
+		}
 		if head.Hash() == obj.Target {
 			name = obj.Name
 			iter.Close()


### PR DESCRIPTION
For annotated tags, we need to check the [target `ref`](https://pkg.go.dev/github.com/go-git/go-git/v5@v5.5.2/plumbing/object#Tag) instead of ref of tag object

Fixes https://github.com/launchdarkly/ld-find-code-refs/issues/329