### PR TITLE
Update module-path to v2

### DIFF
--- a/aliases/alias.go
+++ b/aliases/alias.go
@@ -15,10 +15,10 @@ import (
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/iancoleman/strcase"
 
-	"github.com/launchdarkly/ld-find-code-refs/internal/helpers"
-	"github.com/launchdarkly/ld-find-code-refs/internal/log"
-	"github.com/launchdarkly/ld-find-code-refs/internal/validation"
-	"github.com/launchdarkly/ld-find-code-refs/options"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/helpers"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/log"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/validation"
+	"github.com/launchdarkly/ld-find-code-refs/v2/options"
 )
 
 // GenerateAliases returns a map of flag keys to aliases based on config.

--- a/aliases/alias_test.go
+++ b/aliases/alias_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/launchdarkly/ld-find-code-refs/internal/log"
-	o "github.com/launchdarkly/ld-find-code-refs/options"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/log"
+	o "github.com/launchdarkly/ld-find-code-refs/v2/options"
 )
 
 var allNamingConventions = []o.Alias{

--- a/build/package/bitbucket-pipelines/bitbucket-pipelines.go
+++ b/build/package/bitbucket-pipelines/bitbucket-pipelines.go
@@ -4,9 +4,9 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/launchdarkly/ld-find-code-refs/coderefs"
-	"github.com/launchdarkly/ld-find-code-refs/internal/log"
-	o "github.com/launchdarkly/ld-find-code-refs/options"
+	"github.com/launchdarkly/ld-find-code-refs/v2/coderefs"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/log"
+	o "github.com/launchdarkly/ld-find-code-refs/v2/options"
 )
 
 func main() {

--- a/build/package/bitbucket-pipelines/bitbucket-pipelines_test.go
+++ b/build/package/bitbucket-pipelines/bitbucket-pipelines_test.go
@@ -4,9 +4,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/launchdarkly/ld-find-code-refs/v2/internal/log"
 	o "github.com/launchdarkly/ld-find-code-refs/v2/options"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestMain(m *testing.M) {

--- a/build/package/bitbucket-pipelines/bitbucket-pipelines_test.go
+++ b/build/package/bitbucket-pipelines/bitbucket-pipelines_test.go
@@ -4,8 +4,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/launchdarkly/ld-find-code-refs/internal/log"
-	o "github.com/launchdarkly/ld-find-code-refs/options"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/log"
+	o "github.com/launchdarkly/ld-find-code-refs/v2/options"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/build/package/github-actions/github-actions.go
+++ b/build/package/github-actions/github-actions.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/launchdarkly/ld-find-code-refs/coderefs"
-	"github.com/launchdarkly/ld-find-code-refs/internal/log"
-	o "github.com/launchdarkly/ld-find-code-refs/options"
+	"github.com/launchdarkly/ld-find-code-refs/v2/coderefs"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/log"
+	o "github.com/launchdarkly/ld-find-code-refs/v2/options"
 )
 
 func main() {

--- a/build/package/github-actions/github-actions_test.go
+++ b/build/package/github-actions/github-actions_test.go
@@ -4,9 +4,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/launchdarkly/ld-find-code-refs/v2/internal/log"
 	o "github.com/launchdarkly/ld-find-code-refs/v2/options"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestMain(m *testing.M) {

--- a/build/package/github-actions/github-actions_test.go
+++ b/build/package/github-actions/github-actions_test.go
@@ -4,8 +4,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/launchdarkly/ld-find-code-refs/internal/log"
-	o "github.com/launchdarkly/ld-find-code-refs/options"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/log"
+	o "github.com/launchdarkly/ld-find-code-refs/v2/options"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/cmd/ld-find-code-refs/main.go
+++ b/cmd/ld-find-code-refs/main.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/launchdarkly/ld-find-code-refs/coderefs"
-	"github.com/launchdarkly/ld-find-code-refs/internal/log"
-	"github.com/launchdarkly/ld-find-code-refs/internal/version"
-	o "github.com/launchdarkly/ld-find-code-refs/options"
+	"github.com/launchdarkly/ld-find-code-refs/v2/coderefs"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/log"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/version"
+	o "github.com/launchdarkly/ld-find-code-refs/v2/options"
 )
 
 var prune = &cobra.Command{

--- a/coderefs/coderefs.go
+++ b/coderefs/coderefs.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/launchdarkly/ld-find-code-refs/internal/git"
-	"github.com/launchdarkly/ld-find-code-refs/internal/helpers"
-	"github.com/launchdarkly/ld-find-code-refs/internal/ld"
-	"github.com/launchdarkly/ld-find-code-refs/internal/log"
-	"github.com/launchdarkly/ld-find-code-refs/internal/validation"
-	"github.com/launchdarkly/ld-find-code-refs/options"
-	"github.com/launchdarkly/ld-find-code-refs/search"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/git"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/helpers"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/ld"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/log"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/validation"
+	"github.com/launchdarkly/ld-find-code-refs/v2/options"
+	"github.com/launchdarkly/ld-find-code-refs/v2/search"
 )
 
 func Run(opts options.Options, output bool) {

--- a/coderefs/coderefs_test.go
+++ b/coderefs/coderefs_test.go
@@ -4,8 +4,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/launchdarkly/ld-find-code-refs/internal/ld"
-	"github.com/launchdarkly/ld-find-code-refs/internal/log"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/ld"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/log"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/coderefs/coderefs_test.go
+++ b/coderefs/coderefs_test.go
@@ -4,9 +4,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/launchdarkly/ld-find-code-refs/v2/internal/ld"
 	"github.com/launchdarkly/ld-find-code-refs/v2/internal/log"
-	"github.com/stretchr/testify/assert"
 )
 
 func init() {

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/launchdarkly/ld-find-code-refs/internal/helpers"
-	"github.com/launchdarkly/ld-find-code-refs/internal/ld"
-	"github.com/launchdarkly/ld-find-code-refs/internal/log"
-	"github.com/launchdarkly/ld-find-code-refs/options"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/helpers"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/ld"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/log"
+	"github.com/launchdarkly/ld-find-code-refs/v2/options"
 )
 
 const (

--- a/flags/flags_test.go
+++ b/flags/flags_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/launchdarkly/ld-find-code-refs/internal/log"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/log"
 )
 
 func init() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/launchdarkly/ld-find-code-refs
+module github.com/launchdarkly/ld-find-code-refs/v2
 
 go 1.18
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -14,11 +14,11 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/format/diff"
 	object "github.com/go-git/go-git/v5/plumbing/object"
 
-	"github.com/launchdarkly/ld-find-code-refs/internal/ld"
-	"github.com/launchdarkly/ld-find-code-refs/options"
-	"github.com/launchdarkly/ld-find-code-refs/search"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/ld"
+	"github.com/launchdarkly/ld-find-code-refs/v2/options"
+	"github.com/launchdarkly/ld-find-code-refs/v2/search"
 
-	"github.com/launchdarkly/ld-find-code-refs/internal/log"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/log"
 )
 
 type Client struct {

--- a/internal/git/git_integration_test.go
+++ b/internal/git/git_integration_test.go
@@ -8,11 +8,11 @@ import (
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/stretchr/testify/require"
+
 	"github.com/launchdarkly/ld-find-code-refs/v2/internal/ld"
 	"github.com/launchdarkly/ld-find-code-refs/v2/internal/log"
 	"github.com/launchdarkly/ld-find-code-refs/v2/options"
-	"github.com/stretchr/testify/require"
-
 	"github.com/launchdarkly/ld-find-code-refs/v2/search"
 )
 

--- a/internal/git/git_integration_test.go
+++ b/internal/git/git_integration_test.go
@@ -8,12 +8,12 @@ import (
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing/object"
-	"github.com/launchdarkly/ld-find-code-refs/internal/ld"
-	"github.com/launchdarkly/ld-find-code-refs/internal/log"
-	"github.com/launchdarkly/ld-find-code-refs/options"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/ld"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/log"
+	"github.com/launchdarkly/ld-find-code-refs/v2/options"
 	"github.com/stretchr/testify/require"
 
-	"github.com/launchdarkly/ld-find-code-refs/search"
+	"github.com/launchdarkly/ld-find-code-refs/v2/search"
 )
 
 const (

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/launchdarkly/ld-find-code-refs/internal/ld"
-	"github.com/launchdarkly/ld-find-code-refs/internal/log"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/ld"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/log"
 )
 
 func Dedupe(s []string) []string {

--- a/internal/helpers/user-agent.go
+++ b/internal/helpers/user-agent.go
@@ -3,7 +3,7 @@ package helpers
 import (
 	"fmt"
 
-	"github.com/launchdarkly/ld-find-code-refs/internal/version"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/version"
 )
 
 func GetUserAgent(u string) string {

--- a/internal/ld/ld.go
+++ b/internal/ld/ld.go
@@ -23,8 +23,8 @@ import (
 
 	ldapi "github.com/launchdarkly/api-client-go/v7"
 	jsonpatch "github.com/launchdarkly/json-patch"
-	"github.com/launchdarkly/ld-find-code-refs/internal/log"
-	"github.com/launchdarkly/ld-find-code-refs/internal/validation"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/log"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/validation"
 )
 
 type ApiClient struct {

--- a/internal/ld/ld_test.go
+++ b/internal/ld/ld_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/launchdarkly/ld-find-code-refs/internal/log"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/log"
 )
 
 func TestMain(m *testing.M) {

--- a/options/options.go
+++ b/options/options.go
@@ -13,7 +13,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
-	"github.com/launchdarkly/ld-find-code-refs/internal/validation"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/validation"
 )
 
 const (

--- a/search/files.go
+++ b/search/files.go
@@ -11,7 +11,7 @@ import (
 	"github.com/monochromegane/go-gitignore"
 	"golang.org/x/tools/godoc/util"
 
-	"github.com/launchdarkly/ld-find-code-refs/internal/validation"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/validation"
 )
 
 type ignore struct {

--- a/search/matcher.go
+++ b/search/matcher.go
@@ -5,12 +5,12 @@ import (
 
 	ahocorasick "github.com/petar-dambovaliev/aho-corasick"
 
-	"github.com/launchdarkly/ld-find-code-refs/aliases"
-	"github.com/launchdarkly/ld-find-code-refs/flags"
-	"github.com/launchdarkly/ld-find-code-refs/internal/helpers"
-	"github.com/launchdarkly/ld-find-code-refs/internal/ld"
-	"github.com/launchdarkly/ld-find-code-refs/internal/log"
-	"github.com/launchdarkly/ld-find-code-refs/options"
+	aliases "github.com/launchdarkly/ld-find-code-refs/v2/aliases"
+	"github.com/launchdarkly/ld-find-code-refs/v2/flags"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/helpers"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/ld"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/log"
+	"github.com/launchdarkly/ld-find-code-refs/v2/options"
 )
 
 type ElementMatcher struct {

--- a/search/matcher.go
+++ b/search/matcher.go
@@ -5,7 +5,7 @@ import (
 
 	ahocorasick "github.com/petar-dambovaliev/aho-corasick"
 
-	aliases "github.com/launchdarkly/ld-find-code-refs/v2/aliases"
+	"github.com/launchdarkly/ld-find-code-refs/v2/aliases"
 	"github.com/launchdarkly/ld-find-code-refs/v2/flags"
 	"github.com/launchdarkly/ld-find-code-refs/v2/internal/helpers"
 	"github.com/launchdarkly/ld-find-code-refs/v2/internal/ld"

--- a/search/search.go
+++ b/search/search.go
@@ -25,8 +25,7 @@ const (
 
 // Truncate lines to prevent sending over massive hunks, e.g. a minified file.
 // NOTE: We may end up truncating a valid flag key reference. We accept this risk
-//
-//	and will handle hunks missing flag key references on the frontend.
+// and will handle hunks missing flag key references on the frontend.
 func truncateLine(line string, maxCharCount int) string {
 	if utf8.RuneCountInString(line) <= maxCharCount {
 		return line

--- a/search/search.go
+++ b/search/search.go
@@ -8,8 +8,8 @@ import (
 	"unicode/utf8"
 
 	"github.com/go-git/go-git/v5/plumbing"
-	"github.com/launchdarkly/ld-find-code-refs/internal/helpers"
-	"github.com/launchdarkly/ld-find-code-refs/internal/ld"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/helpers"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/ld"
 )
 
 const (
@@ -25,7 +25,8 @@ const (
 
 // Truncate lines to prevent sending over massive hunks, e.g. a minified file.
 // NOTE: We may end up truncating a valid flag key reference. We accept this risk
-//       and will handle hunks missing flag key references on the frontend.
+//
+//	and will handle hunks missing flag key references on the frontend.
 func truncateLine(line string, maxCharCount int) string {
 	if utf8.RuneCountInString(line) <= maxCharCount {
 		return line

--- a/search/search_test.go
+++ b/search/search_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/launchdarkly/ld-find-code-refs/internal/ld"
-	"github.com/launchdarkly/ld-find-code-refs/internal/log"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/ld"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/log"
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
module path should be updated for v2+

> module-path
The module's module path, usually the repository location from which the module can be downloaded by Go tools. For module versions v2 and later, this value must end with the major version number, such as /v2.

- [docs](https://go.dev/doc/modules/gomod-ref)

--

test with 

```
go get github.com/launchdarkly/ld-find-code-refs/v2@c5029a63b4da2a6ff9efbf63b400b16eff343d6c
```