### PR TITLE
[sc-210848] exclude flag key itself from alias list

### DIFF
--- a/aliases/alias.go
+++ b/aliases/alias.go
@@ -40,9 +40,23 @@ func GenerateAliases(flags []string, aliases []options.Alias, dir string) (map[s
 			}
 			ret[flag] = append(ret[flag], flagAliases...)
 		}
-		ret[flag] = helpers.Dedupe(ret[flag])
+		ret[flag] = uniqueAliases(flag, ret[flag])
 	}
 	return ret, nil
+}
+
+// Return a unique list of aliase, excluding flag key itself
+func uniqueAliases(flagKey string, aliases []string) []string {
+	ret := make([]string, 0, len(aliases))
+	keys := make(map[string]bool, len(aliases))
+	keys[flagKey] = true
+	for _, a := range aliases {
+		if _, ok := keys[a]; !ok {
+			keys[a] = true
+			ret = append(ret, a)
+		}
+	}
+	return ret
 }
 
 func generateAlias(a options.Alias, flag, dir string, allFileContents map[string][]byte) ([]string, error) {

--- a/aliases/alias_test.go
+++ b/aliases/alias_test.go
@@ -22,11 +22,11 @@ var allNamingConventions = []o.Alias{
 var allSomeFlagNamingConventionAliases = slice("anyKindOfKey", "AnyKindOfKey", "any_kind_of_key", "ANY_KIND_OF_KEY", "any-kind-of-key", "any.kind.of.key")
 
 const (
-	testFlagAlias    = "test-flag"
-	testFlagKey      = "someFlag"
-	testFlagKey2     = "anotherFlag"
-	testFlagAliasKey = "AnyKind.of_key"
-	testWildFlagKey  = "wildFlag"
+	testFlagKebabCase = "test-flag"
+	testFlagKey       = "someFlag"
+	testFlagKey2      = "anotherFlag"
+	testFlagAliasKey  = "AnyKind.of_key"
+	testWildFlagKey   = "wildFlag"
 )
 
 func TestMain(m *testing.M) {
@@ -72,6 +72,14 @@ func Test_GenerateAliases(t *testing.T) {
 				alias(o.PascalCase),
 			},
 			want: map[string][]string{testFlagKey: slice("SomeFlag")},
+		},
+		{
+			name:  "alias matches own key",
+			flags: slice(testFlagKebabCase),
+			aliases: []o.Alias{
+				alias(o.KebabCase),
+			},
+			want: map[string][]string{testFlagKebabCase: {}},
 		},
 		{
 			name:  "file exact pattern",


### PR DESCRIPTION
For given flag key "test-flag" with configured `kebabcase` alias, own key "test-flag" should not be considered an alias

This will reduce scanning required.