### PR TITLE
[sc-212684] update goreleaser and configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
       - setup_remote_docker
       - run: sudo apt-get update
       - run: sudo apt-get install rpm
-      - run: curl -sL https://git.io/goreleaser | VERSION=v0.169.0 bash -s -- --rm-dist --skip-publish --skip-validate
+      - run: curl -sL https://git.io/goreleaser | VERSION=v1.20.0 bash -s -- --rm-dist --skip-publish --skip-validate
 
   github-actions-docs:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,8 +73,7 @@ jobs:
       - setup_remote_docker
       - run: sudo apt-get update
       - run: sudo apt-get install rpm
-      - run: curl -sL https://git.io/goreleaser | VERSION=v1.20.0 bash -s -- --clean --skip-publish --skip-validate
-
+      - run: make test-publish
   github-actions-docs:
     docker:
       - image: cimg/node:18.8.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
       - setup_remote_docker
       - run: sudo apt-get update
       - run: sudo apt-get install rpm
-      - run: curl -sL https://git.io/goreleaser | VERSION=v1.20.0 bash -s -- --rm-dist --skip-publish --skip-validate
+      - run: curl -sL https://git.io/goreleaser | VERSION=v1.5.0 bash -s -- --rm-dist --skip-publish --skip-validate
 
   github-actions-docs:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
       - setup_remote_docker
       - run: sudo apt-get update
       - run: sudo apt-get install rpm
-      - run: curl -sL https://git.io/goreleaser | VERSION=v1.20.0 bash -s -- --rm-dist --skip-publish --skip-validate
+      - run: curl -sL https://git.io/goreleaser | VERSION=v1.20.0 bash -s -- --clean --skip-publish --skip-validate
 
   github-actions-docs:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
       - setup_remote_docker
       - run: sudo apt-get update
       - run: sudo apt-get install rpm
-      - run: curl -sL https://git.io/goreleaser | VERSION=v1.5.0 bash -s -- --rm-dist --skip-publish --skip-validate
+      - run: curl -sL https://git.io/goreleaser | VERSION=v1.20.0 bash -s -- --rm-dist --skip-publish --skip-validate
 
   github-actions-docs:
     docker:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,7 +47,11 @@ archives:
 nfpms:
   -
     id: ld-find-code-refs
-    file_name_template: "{{ .ProjectName }}_{{ .Version }}.{{ .Arch }}"
+    file_name_template: >-
+      {{ .ProjectName }}_
+      {{ .Version }}.
+      {{- if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
 
     homepage: https://launchdarkly.com/
     maintainer: LaunchDarkly <team@launchdarkly.com>
@@ -59,14 +63,11 @@ nfpms:
     - deb
     - rpm
 
-    replacements:
-      386: i386
-
 brews:
   -
-    ids: 
+    ids:
     - ld-find-code-refs
-    
+
     name: ld-find-code-refs
 
     description: Job for finding and sending feature flag code references to LaunchDarkly
@@ -98,21 +99,21 @@ dockers:
     image_templates:
     - "launchdarkly/ld-find-code-refs:latest"
     - "launchdarkly/ld-find-code-refs:{{ .Version }}"
-      
+
     dockerfile: build/package/cmd/Dockerfile
- 
+
   -
     goos: linux
 
     # GOARCH of the built binaries/packages that should be used.
     goarch: amd64
-    ids: 
+    ids:
     - ld-find-code-refs-github-action
 
     image_templates:
     - "launchdarkly/ld-find-code-refs-github-action:latest"
     - "launchdarkly/ld-find-code-refs-github-action:{{ .Version }}"
-      
+
     dockerfile: Dockerfile.github
   -
     goos: linux
@@ -123,8 +124,8 @@ dockers:
     image_templates:
     - "launchdarkly/ld-find-code-refs-bitbucket-pipeline:latest"
     - "launchdarkly/ld-find-code-refs-bitbucket-pipeline:{{ .Version }}"
-     
-    ids: 
+
+    ids:
     - ld-find-code-refs-bitbucket-pipeline
 
     dockerfile: Dockerfile.bitbucket

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -74,7 +74,7 @@ brews:
 
     homepage: "https://launchdarkly.com"
 
-    tap:
+    repository:
       owner: launchdarkly
       name: homebrew-tap
       token: "{{ .Env.GITHUB_TOKEN }}"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Note: These commands pertain to the development of ld-find-code-refs.
 #       They are not intended for use by the end-users of this program.
 SHELL=/bin/bash
-GORELEASER_VERSION=v1.5.0
+GORELEASER_VERSION=v1.20.0
 
 build:
 	go build ./cmd/...
@@ -72,10 +72,13 @@ clean:
 	rm -f build/package/github-actions/ld-find-code-refs-github-action
 	rm -f build/package/bitbucket-pipelines/ld-find-code-refs-bitbucket-pipeline
 
-RELEASE_CMD=curl -sL https://git.io/goreleaser | GOPATH=$(mktemp -d) VERSION=$(GORELEASER_VERSION) GITHUB_TOKEN=$(GITHUB_TOKEN) bash -s -- --rm-dist --release-notes $(RELEASE_NOTES)
+RELEASE_CMD=curl -sL https://git.io/goreleaser | GOPATH=$(mktemp -d) VERSION=$(GORELEASER_VERSION) GITHUB_TOKEN=$(GITHUB_TOKEN) bash -s -- --clean --release-notes $(RELEASE_NOTES)
 
 publish:
 	$(RELEASE_CMD)
+
+test-publish:
+	curl -sL https://git.io/goreleaser | VERSION=$(GORELEASER_VERSION) bash -s -- --clean --skip-publish --skip-validate
 
 products-for-release:
 	$(RELEASE_CMD) --skip-publish --skip-validate


### PR DESCRIPTION
Update:

More reliable build & build test CI

Specifics:

1. CI goreleaser version didn't match version used by release command
2. Update to latest version of goreleaser to fix [darwin/arm64](https://goreleaser.com/deprecations/#builds-for-darwinarm64) and [windows/arm64](https://goreleaser.com/deprecations/#builds-for-windowsarm64) deprecation warnings
3. Use new template format without [replacements](https://goreleaser.com/deprecations/#nfpmsreplacements)
4. [brews.tap](https://goreleaser.com/deprecations/#brewstap) is deprecated
5. --rm-dist is now --clean