### PR TITLE
fix: incorrect names for some release assets

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,8 +48,8 @@ nfpms:
   -
     id: ld-find-code-refs
     file_name_template: >-
-      {{ .ProjectName }}_
-      {{ .Version }}.
+      {{- .ProjectName -}}_
+      {{- .Version -}}.
       {{- if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end -}}
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,7 +51,7 @@ nfpms:
       {{ .ProjectName }}_
       {{ .Version }}.
       {{- if eq .Arch "386" }}i386
-      {{- else }}{{ .Arch }}{{ end }}
+      {{- else }}{{ .Arch }}{{ end -}}
 
     homepage: https://launchdarkly.com/
     maintainer: LaunchDarkly <team@launchdarkly.com>


### PR DESCRIPTION
Fix extra space before version in [text template](https://pkg.go.dev/text/template)

Confirmed fixed here: https://app.circleci.com/pipelines/github/launchdarkly/ld-find-code-refs/951/workflows/6488d332-5a17-4730-9f3a-6e0e2a5c5e3c/jobs/3343