### PR TITLE
test: demonstrate alias conversion

### DIFF
--- a/aliases/alias_test.go
+++ b/aliases/alias_test.go
@@ -82,6 +82,14 @@ func Test_GenerateAliases(t *testing.T) {
 			want: map[string][]string{"some_flag": slice("SomeFlag")},
 		},
 		{
+			name:  "screaming snake case to camel case",
+			flags: slice("SOME_FLAG"),
+			aliases: []o.Alias{
+				alias(o.CamelCase),
+			},
+			want: map[string][]string{"SOME_FLAG": slice("someFlag")},
+		},
+		{
 			name:  "file exact pattern",
 			flags: slice(testFlagKey),
 			aliases: []o.Alias{


### PR DESCRIPTION
fix in [strcase dependency](https://github.com/launchdarkly/ld-find-code-refs/pull/365) properly converts screaming snake case to camelcase

`MY_FLAG` to `myFlag`