### PR TITLE
docs: remove old docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,25 @@ Configuration options include, but are not limited to:
 
 <!-- Headers are used here to maintain historic section links -->
 - ##### Ignoring files and directories
+
+[Ignoring files and directories](docs/CONFIGURATION.md#ignoring-files-and-directories)
+
 - ##### Searching for flag key aliases, such as keys stored in variables or evaluated in an SDK wrapper
+
+[Feature flag aliases](docs/ALIASES.md)
+
 - ##### Providing flag key delimiters to reduce false positives and false negatives
+
+[Delimiters](docs/CONFIGURATION.md#delimiters)
+
 - ##### Customizing the amount of data stored and displayed by LaunchDarkly
+
+[Configuration with context lines](docs/EXAMPLES.md#configuration-with-context-lines)
+
 - ##### Exporting code references as a CSV file
+
+[All command-line arguments](docs/CONFIGURATION.md#command-line)
+<!-- end historic links -->
 
 ### Searching for unused flags (extinctions)
 

--- a/README.md
+++ b/README.md
@@ -108,26 +108,25 @@ If you are using the FedRAMP compliant [LaunchDarkly federal instance](https://d
 
 `ld-find-code-refs` provides a number of configuration options to customize how code references are generated and surfaced in your LaunchDarkly dashboard. See [CONFIGURATION.md](docs/CONFIGURATION.md) for details on configuration, and [EXAMPLES.md](docs/EXAMPLES.md) for detailed sample configurations.
 
-Configuration options include, but are not limited to:
 
 <!-- Headers are used here to maintain historic section links -->
-- ##### Ignoring files and directories
+#### Ignoring files and directories
 
 [Ignoring files and directories](docs/CONFIGURATION.md#ignoring-files-and-directories)
 
-- ##### Searching for flag key aliases, such as keys stored in variables or evaluated in an SDK wrapper
+#### Searching for flag key aliases, such as keys stored in variables or evaluated in an SDK wrapper
 
 [Feature flag aliases](docs/ALIASES.md)
 
-- ##### Providing flag key delimiters to reduce false positives and false negatives
+#### Providing flag key delimiters to reduce false positives and false negatives
 
 [Delimiters](docs/CONFIGURATION.md#delimiters)
 
-- ##### Customizing the amount of data stored and displayed by LaunchDarkly
+#### Customizing the amount of data stored and displayed by LaunchDarkly
 
 [Configuration with context lines](docs/EXAMPLES.md#configuration-with-context-lines)
 
-- ##### Exporting code references as a CSV file
+#### Exporting code references as a CSV file
 
 [All command-line arguments](docs/CONFIGURATION.md#command-line)
 <!-- end historic links -->

--- a/README.md
+++ b/README.md
@@ -104,32 +104,13 @@ Precompiled binaries for the latest release can be found [here](https://github.c
 
 If you are using the FedRAMP compliant [LaunchDarkly federal instance](https://docs.launchdarkly.com/home/advanced/federal), the `ld-find-code-refs` binary should be compiled with FIPS 140-2 support by using a tool like [Go+BoringCrypto](https://github.com/golang/go/tree/dev.boringcrypto/misc/boring).
 
-### CLI Configuration
+### Configuration
 
-`ld-find-code-refs` provides a number of configuration options to customize how code references are generated and surfaced in your LaunchDarkly dashboard. See [CONFIGURATION.md](docs/CONFIGURATION.md) for details on configuration, and [EXAMPLES.md](docs/EXAMPLES.md) for detailed sample configurations.
+`ld-find-code-refs` provides a number of configuration options to customize how code references are generated and surfaced in your LaunchDarkly dashboard.
 
-
-<!-- Headers are used here to maintain historic section links -->
-#### Ignoring files and directories
-
-[Ignoring files and directories](docs/CONFIGURATION.md#ignoring-files-and-directories)
-
-#### Searching for flag key aliases, such as keys stored in variables or evaluated in an SDK wrapper
-
-[Feature flag aliases](docs/ALIASES.md)
-
-#### Providing flag key delimiters to reduce false positives and false negatives
-
-[Delimiters](docs/CONFIGURATION.md#delimiters)
-
-#### Customizing the amount of data stored and displayed by LaunchDarkly
-
-[Configuration with context lines](docs/EXAMPLES.md#configuration-with-context-lines)
-
-#### Exporting code references as a CSV file
-
-[All command-line arguments](docs/CONFIGURATION.md#command-line)
-<!-- end historic links -->
+- [All configuration options are documented in CONFIGURATION.md](docs/CONFIGURATION.md)
+- [Common configuration examples are documented in EXAMPLES.md](docs/EXAMPLES.md)
+- [Detailed information on configuring feature flag aliases is documented in ALIASES.md](docs/ALIASES.md)
 
 ### Searching for unused flags (extinctions)
 


### PR DESCRIPTION
We moved some docs content around awhile ago, leaving some weird headings w/content in the readme - it's been multiple years, so I feel we can safely remove them.

This also revises the configuration section with links to relevant `/docs` files.