### PR TITLE
[sc-223067] allow branch pruning to be disabled in main job

### DIFF
--- a/build/metadata/github-actions/README.md
+++ b/build/metadata/github-actions/README.md
@@ -86,4 +86,5 @@ If the action fails, there may be a problem with your configuration. To investig
 | lookback | Set the number of commits to search in history for whether you removed a feature flag from code. You may set to 0 to disable this feature. Setting this option to a high value will increase search time. | `false` | 10 |
 | projKey | Key of the LaunchDarkly project associated with this repository. Found under Account Settings -> Projects in the LaunchDarkly dashboard. Cannot be combined with `projects` block in configuration file. | `false` |  |
 | repoName | The repository name. Defaults to the current GitHub repository. | `false` |  |
+| prune | There is a known issue where the GitHub Action will not prune deleted branch data in private repos. Only enable this if you are running the action in a public repo. | `false` | false |
 <!-- action-docs-inputs -->

--- a/build/metadata/github-actions/action.yml
+++ b/build/metadata/github-actions/action.yml
@@ -38,6 +38,10 @@ inputs:
   repoName: 
     description: "The repository name. Defaults to the current GitHub repository."
     required: false
+  prune:
+    default: "false"
+    description: "There is a known issue where the GitHub Action will not prune deleted branch data in private repos. Only enable this if you are running the action in a public repo."
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -51,3 +55,4 @@ runs:
     LD_DEBUG: ${{ inputs.debug }}
     LD_IGNORE_SERVICE_ERRORS: ${{ inputs.ignoreServiceErrors }}
     LD_LOOKBACK: ${{ inputs.lookback }}
+    LD_PRUNE: ${{ inputs.prune }}

--- a/build/package/github-actions/github-actions.go
+++ b/build/package/github-actions/github-actions.go
@@ -65,6 +65,7 @@ func mergeGithubOptions(opts o.Options) (o.Options, error) {
 	opts.Branch = ghBranch
 	opts.UpdateSequenceId = updateSequenceId
 	opts.UserAgent = "github-actions"
+	opts.Prune = false // Temporary, since pruning doesn't work in private repos
 
 	return opts, opts.Validate()
 }

--- a/build/package/github-actions/github-actions.go
+++ b/build/package/github-actions/github-actions.go
@@ -65,7 +65,6 @@ func mergeGithubOptions(opts o.Options) (o.Options, error) {
 	opts.Branch = ghBranch
 	opts.UpdateSequenceId = updateSequenceId
 	opts.UserAgent = "github-actions"
-	opts.Prune = false // Temporary, since pruning doesn't work in private repos
 
 	return opts, opts.Validate()
 }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -57,6 +57,7 @@ Flags:
   -o, --outDir string              If provided, will output a csv file containing all code references for the project to this directory.
 
   -p, --projKey string             LaunchDarkly project key. Found under Account Settings -> Projects in the LaunchDarkly dashboard. Cannot be combined with "projects" block in configuration file.
+
       --prune                      If enabled, branches that are not found in the remote repository will be deleted from LaunchDarkly. (default true)
 
   -r, --repoName string            Repository name. Will be displayed in LaunchDarkly. Case insensitive. Repository names must only contain letters, numbers, '.', '_' or '-'."

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -44,18 +44,20 @@ Flags:
   -B, --defaultBranch string       The default branch. The LaunchDarkly UI will default to this branch. If not provided, will fallback to 'main'. (default "main")
 
   -d, --dir string                 Path to existing checkout of the repository.
-
       --dryRun                     If enabled, the scanner will run without sending code references to LaunchDarkly. Combine with the outDir option to output code references to a CSV.
 
   -h, --help                       help for ld-find-code-refs
 
       --hunkUrlTemplate string     If provided, LaunchDarkly will attempt to generate links to  your VCS service provider per code reference.  Example: https://github.com/launchdarkly/ld-find-code-refs/blob/${sha}/${filePath}#L${lineNumber}. Allowed template variables: 'sha', 'filePath', 'lineNumber'. If "hunkUrlTemplate" is not provided, but "repoUrl" is provided and "repoType" is not custom, LaunchDarkly will attempt to automatically generate source code links for the given "repoType".
+
   -i, --ignoreServiceErrors        If enabled, the scanner will terminate with exit code 0 when the LaunchDarkly API is unreachable or returns an unexpected response.
 
   -l, --lookback int               Sets the number of git commits to search in history for whether a feature flag was removed from code. May be set to 0 to disabled this feature. Setting this option to a high value will increase search time. (default 10)
+
   -o, --outDir string              If provided, will output a csv file containing all code references for the project to this directory.
 
   -p, --projKey string             LaunchDarkly project key. Found under Account Settings -> Projects in the LaunchDarkly dashboard. Cannot be combined with "projects" block in configuration file.
+      --prune                      If enabled, branches that are not found in the remote repository will be deleted from LaunchDarkly. (default true)
 
   -r, --repoName string            Repository name. Will be displayed in LaunchDarkly. Case insensitive. Repository names must only contain letters, numbers, '.', '_' or '-'."
 
@@ -66,6 +68,8 @@ Flags:
   -R, --revision string            Use this option to scan non-git codebases. The current revision of the repository to be scanned. If set, the version string for the scanned repository will not be inferred, and branch garbage collection will be disabled. The "branch" option is required when "revision" is set.
 
   -s, --updateSequenceId int       An integer representing the order number of code reference updates. Used to version updates across concurrent executions of the flag finder. If not provided, data will always be updated. If provided, data will only be updated if the existing "updateSequenceId" is less than the new "updateSequenceId". Examples: the time a "git push" was initiated, CI build number, the current unix timestamp. (default -1)
+
+      --userAgent string           (Internal) Platform where code references is run.
 
   -v, --version                    version for ld-find-code-refs
 ```

--- a/options/flags.go
+++ b/options/flags.go
@@ -112,6 +112,11 @@ the project to this directory.`,
 		usage:        `LaunchDarkly project key. Found under Account Settings -> Projects in the LaunchDarkly dashboard. Cannot be combined with "projects" block in configuration file.`,
 	},
 	{
+		name:         "prune",
+		defaultValue: true,
+		usage:        `If enabled, branches that are not found in the remote repository will be deleted from LaunchDarkly.`,
+	},
+	{
 		name:         "repoName",
 		short:        "r",
 		defaultValue: "",

--- a/options/options.go
+++ b/options/options.go
@@ -65,6 +65,7 @@ type Options struct {
 	DryRun              bool   `mapstructure:"dryRun"`
 	IgnoreServiceErrors bool   `mapstructure:"ignoreServiceErrors"`
 	UserAgent           string `mapstructure:"userAgent"`
+	Prune               bool   `mapstructure:"prune"`
 
 	// The following options can only be configured via YAML configuration
 

--- a/options/options.go
+++ b/options/options.go
@@ -57,6 +57,7 @@ type Options struct {
 	RepoType            string `mapstructure:"repoType"`
 	RepoUrl             string `mapstructure:"repoUrl"`
 	Revision            string `mapstructure:"revision"`
+	UserAgent           string `mapstructure:"userAgent"`
 	ContextLines        int    `mapstructure:"contextLines"`
 	Lookback            int    `mapstructure:"lookback"`
 	UpdateSequenceId    int    `mapstructure:"updateSequenceId"`
@@ -64,7 +65,6 @@ type Options struct {
 	Debug               bool   `mapstructure:"debug"`
 	DryRun              bool   `mapstructure:"dryRun"`
 	IgnoreServiceErrors bool   `mapstructure:"ignoreServiceErrors"`
-	UserAgent           string `mapstructure:"userAgent"`
 	Prune               bool   `mapstructure:"prune"`
 
 	// The following options can only be configured via YAML configuration


### PR DESCRIPTION
Summary
1. allow pruning step to be skipped in code refs job
2. disable pruning by default in github action

more details

This will help silence ongoing error messages in GitHub Action until we are able to implement a suitable fix.

It's also just a good idea to allow this to be disabled in case a user has a reason for keeping old branches.