### PR TITLE
chore: reorganize search package

### DIFF
--- a/search/delimiters.go
+++ b/search/delimiters.go
@@ -1,0 +1,14 @@
+package search
+
+import "github.com/launchdarkly/ld-find-code-refs/v2/options"
+
+func getDelimiters(opts options.Options) []string {
+	delims := []string{`"`, `'`, "`"}
+	if opts.Delimiters.DisableDefaults {
+		delims = []string{}
+	}
+
+	delims = append(delims, opts.Delimiters.Additional...)
+
+	return delims
+}

--- a/search/delimiters.go
+++ b/search/delimiters.go
@@ -5,6 +5,8 @@ import (
 	"github.com/launchdarkly/ld-find-code-refs/v2/options"
 )
 
+// Get a list of delimiters to use for flag key matching
+// If defaults are disabled, only additional configured delimiters will be used
 func GetDelimiters(opts options.Options) []string {
 	delims := []string{`"`, `'`, "`"}
 	if opts.Delimiters.DisableDefaults {

--- a/search/delimiters.go
+++ b/search/delimiters.go
@@ -1,8 +1,11 @@
 package search
 
-import "github.com/launchdarkly/ld-find-code-refs/v2/options"
+import (
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/helpers"
+	"github.com/launchdarkly/ld-find-code-refs/v2/options"
+)
 
-func getDelimiters(opts options.Options) []string {
+func GetDelimiters(opts options.Options) []string {
 	delims := []string{`"`, `'`, "`"}
 	if opts.Delimiters.DisableDefaults {
 		delims = []string{}
@@ -10,5 +13,5 @@ func getDelimiters(opts options.Options) []string {
 
 	delims = append(delims, opts.Delimiters.Additional...)
 
-	return delims
+	return helpers.Dedupe(delims)
 }

--- a/search/element_matcher.go
+++ b/search/element_matcher.go
@@ -1,0 +1,82 @@
+package search
+
+import (
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/helpers"
+	ahocorasick "github.com/petar-dambovaliev/aho-corasick"
+)
+
+type ElementMatcher struct {
+	ProjKey                     string
+	Elements                    []string
+	Dir                         string
+	allElementAndAliasesMatcher ahocorasick.AhoCorasick
+	matcherByElement            map[string]ahocorasick.AhoCorasick
+	aliasMatcherByElement       map[string]ahocorasick.AhoCorasick
+
+	elementsByPatternIndex [][]string
+}
+
+func (m ElementMatcher) FindMatches(line string) []string {
+	elements := make([]string, 0)
+	iter := m.allElementAndAliasesMatcher.IterOverlapping(line)
+	for match := iter.Next(); match != nil; match = iter.Next() {
+		elements = append(elements, m.elementsByPatternIndex[match.Pattern()]...)
+	}
+	return helpers.Dedupe(elements)
+}
+
+func (m ElementMatcher) FindAliases(line, element string) []string {
+	aliasMatches := make([]string, 0)
+	if aliasMatcher, exists := m.aliasMatcherByElement[element]; exists {
+		iter := aliasMatcher.IterOverlapping(line)
+		for match := iter.Next(); match != nil; match = iter.Next() {
+			aliasMatches = append(aliasMatches, line[match.Start():match.End()])
+		}
+	}
+	return aliasMatches
+}
+
+func NewElementMatcher(projKey, dir, delimiters string, elements []string, aliasesByElement map[string][]string) ElementMatcher {
+	matcherBuilder := ahocorasick.NewAhoCorasickBuilder(ahocorasick.Opts{DFA: true, MatchKind: ahocorasick.StandardMatch})
+
+	allFlagPatternsAndAliases := make([]string, 0)
+	elementsByPatternIndex := make([][]string, 0)
+	patternIndex := make(map[string]int)
+
+	recordPatternsForElement := func(element string, patterns []string) {
+		for _, p := range patterns {
+			index, exists := patternIndex[p]
+			if !exists {
+				allFlagPatternsAndAliases = append(allFlagPatternsAndAliases, p)
+				index = len(elementsByPatternIndex)
+				elementsByPatternIndex = append(elementsByPatternIndex, []string{})
+			}
+			patternIndex[p] = index
+			elementsByPatternIndex[index] = append(elementsByPatternIndex[index], element)
+		}
+	}
+
+	patternsByElement := buildElementPatterns(elements, delimiters)
+	flagMatcherByKey := make(map[string]ahocorasick.AhoCorasick, len(patternsByElement))
+	for element, patterns := range patternsByElement {
+		flagMatcherByKey[element] = matcherBuilder.Build(patterns)
+		recordPatternsForElement(element, patterns)
+	}
+
+	aliasMatcherByElement := make(map[string]ahocorasick.AhoCorasick, len(aliasesByElement))
+	for element, elementAliases := range aliasesByElement {
+		aliasMatcherByElement[element] = matcherBuilder.Build(elementAliases)
+		recordPatternsForElement(element, elementAliases)
+	}
+
+	return ElementMatcher{
+		Elements:                    elements,
+		ProjKey:                     projKey,
+		Dir:                         dir,
+		matcherByElement:            flagMatcherByKey,
+		aliasMatcherByElement:       aliasMatcherByElement,
+		allElementAndAliasesMatcher: matcherBuilder.Build(allFlagPatternsAndAliases),
+
+		elementsByPatternIndex: elementsByPatternIndex,
+	}
+}

--- a/search/matcher.go
+++ b/search/matcher.go
@@ -14,7 +14,7 @@ type Matcher struct {
 	ctxLines int
 }
 
-func NewMatcher(opts options.Options, flagKeys map[string][]string, dir string) Matcher {
+func NewMultiProjectMatcher(opts options.Options, flagKeys map[string][]string, dir string) Matcher {
 	elements := []ElementMatcher{}
 	delimiters := strings.Join(GetDelimiters(opts), "")
 

--- a/search/matcher.go
+++ b/search/matcher.go
@@ -14,7 +14,7 @@ type Matcher struct {
 	ctxLines int
 }
 
-func NewMultiProjectMatcher(opts options.Options, flagKeys map[string][]string, dir string) Matcher {
+func NewMultiProjectMatcher(opts options.Options, dir string, flagKeys map[string][]string) Matcher {
 	elements := make([]ElementMatcher, 0, len(opts.Projects))
 	delimiters := strings.Join(GetDelimiters(opts), "")
 

--- a/search/matcher.go
+++ b/search/matcher.go
@@ -15,7 +15,7 @@ type Matcher struct {
 }
 
 func NewMultiProjectMatcher(opts options.Options, flagKeys map[string][]string, dir string) Matcher {
-	elements := []ElementMatcher{}
+	elements := make([]ElementMatcher, 0, len(opts.Projects))
 	delimiters := strings.Join(GetDelimiters(opts), "")
 
 	for _, project := range opts.Projects {

--- a/search/matcher.go
+++ b/search/matcher.go
@@ -3,116 +3,12 @@ package search
 import (
 	"strings"
 
-	ahocorasick "github.com/petar-dambovaliev/aho-corasick"
-
-	"github.com/launchdarkly/ld-find-code-refs/v2/aliases"
-	"github.com/launchdarkly/ld-find-code-refs/v2/flags"
 	"github.com/launchdarkly/ld-find-code-refs/v2/internal/helpers"
-	"github.com/launchdarkly/ld-find-code-refs/v2/internal/ld"
-	"github.com/launchdarkly/ld-find-code-refs/v2/internal/log"
-	"github.com/launchdarkly/ld-find-code-refs/v2/options"
 )
-
-type ElementMatcher struct {
-	ProjKey                     string
-	Elements                    []string
-	Dir                         string
-	allElementAndAliasesMatcher ahocorasick.AhoCorasick
-	matcherByElement            map[string]ahocorasick.AhoCorasick
-	aliasMatcherByElement       map[string]ahocorasick.AhoCorasick
-
-	elementsByPatternIndex [][]string
-}
 
 type Matcher struct {
 	Elements []ElementMatcher
 	ctxLines int
-}
-
-// Scan checks the configured directory for flags base on the options configured for Code References.
-func Scan(opts options.Options, repoParams ld.RepoParams, dir string) (Matcher, []ld.ReferenceHunksRep) {
-	flagKeys := flags.GetFlagKeys(opts, repoParams)
-	elements := []ElementMatcher{}
-
-	for _, project := range opts.Projects {
-		projectFlags := flagKeys[project.Key]
-		projectAliases := opts.Aliases
-		projectAliases = append(projectAliases, project.Aliases...)
-		aliasesByFlagKey, err := aliases.GenerateAliases(projectFlags, projectAliases, dir)
-		if err != nil {
-			log.Error.Fatalf("failed to generate aliases: %s for project: %s", err, project.Key)
-		}
-
-		delimiters := strings.Join(helpers.Dedupe(getDelimiters(opts)), "")
-		elements = append(elements, NewElementMatcher(project.Key, project.Dir, delimiters, projectFlags, aliasesByFlagKey))
-	}
-	matcher := Matcher{
-		ctxLines: opts.ContextLines,
-		Elements: elements,
-	}
-
-	refs, err := SearchForRefs(dir, matcher)
-	if err != nil {
-		log.Error.Fatalf("error searching for flag key references: %s", err)
-	}
-
-	return matcher, refs
-}
-
-func NewElementMatcher(projKey, dir, delimiters string, elements []string, aliasesByElement map[string][]string) ElementMatcher {
-	matcherBuilder := ahocorasick.NewAhoCorasickBuilder(ahocorasick.Opts{DFA: true, MatchKind: ahocorasick.StandardMatch})
-
-	allFlagPatternsAndAliases := make([]string, 0)
-	elementsByPatternIndex := make([][]string, 0)
-	patternIndex := make(map[string]int)
-
-	recordPatternsForElement := func(element string, patterns []string) {
-		for _, p := range patterns {
-			index, exists := patternIndex[p]
-			if !exists {
-				allFlagPatternsAndAliases = append(allFlagPatternsAndAliases, p)
-				index = len(elementsByPatternIndex)
-				elementsByPatternIndex = append(elementsByPatternIndex, []string{})
-			}
-			patternIndex[p] = index
-			elementsByPatternIndex[index] = append(elementsByPatternIndex[index], element)
-		}
-	}
-
-	patternsByElement := buildElementPatterns(elements, delimiters)
-	flagMatcherByKey := make(map[string]ahocorasick.AhoCorasick, len(patternsByElement))
-	for element, patterns := range patternsByElement {
-		flagMatcherByKey[element] = matcherBuilder.Build(patterns)
-		recordPatternsForElement(element, patterns)
-	}
-
-	aliasMatcherByElement := make(map[string]ahocorasick.AhoCorasick, len(aliasesByElement))
-	for element, elementAliases := range aliasesByElement {
-		aliasMatcherByElement[element] = matcherBuilder.Build(elementAliases)
-		recordPatternsForElement(element, elementAliases)
-	}
-
-	return ElementMatcher{
-		Elements:                    elements,
-		ProjKey:                     projKey,
-		Dir:                         dir,
-		matcherByElement:            flagMatcherByKey,
-		aliasMatcherByElement:       aliasMatcherByElement,
-		allElementAndAliasesMatcher: matcherBuilder.Build(allFlagPatternsAndAliases),
-
-		elementsByPatternIndex: elementsByPatternIndex,
-	}
-}
-
-func getDelimiters(opts options.Options) []string {
-	delims := []string{`"`, `'`, "`"}
-	if opts.Delimiters.DisableDefaults {
-		delims = []string{}
-	}
-
-	delims = append(delims, opts.Delimiters.Additional...)
-
-	return delims
 }
 
 func (m Matcher) MatchElement(line, element string) bool {
@@ -146,24 +42,11 @@ func (m Matcher) FindAliases(line, element string) []string {
 	return helpers.Dedupe(matches)
 }
 
-func (m ElementMatcher) FindMatches(line string) []string {
-	elements := make([]string, 0)
-	iter := m.allElementAndAliasesMatcher.IterOverlapping(line)
-	for match := iter.Next(); match != nil; match = iter.Next() {
-		elements = append(elements, m.elementsByPatternIndex[match.Pattern()]...)
+func (m Matcher) GetElements() (elements [][]string) {
+	for _, element := range m.Elements {
+		elements = append(elements, element.Elements)
 	}
-	return helpers.Dedupe(elements)
-}
-
-func (m ElementMatcher) FindAliases(line, element string) []string {
-	aliasMatches := make([]string, 0)
-	if aliasMatcher, exists := m.aliasMatcherByElement[element]; exists {
-		iter := aliasMatcher.IterOverlapping(line)
-		for match := iter.Next(); match != nil; match = iter.Next() {
-			aliasMatches = append(aliasMatches, line[match.Start():match.End()])
-		}
-	}
-	return aliasMatches
+	return elements
 }
 
 func buildElementPatterns(flags []string, delimiters string) map[string][]string {
@@ -188,11 +71,4 @@ func buildElementPatterns(flags []string, delimiters string) map[string][]string
 		patternsByFlag[flag] = patterns
 	}
 	return patternsByFlag
-}
-
-func (m Matcher) GetElements() (elements [][]string) {
-	for _, element := range m.Elements {
-		elements = append(elements, element.Elements)
-	}
-	return elements
 }

--- a/search/scan.go
+++ b/search/scan.go
@@ -10,7 +10,7 @@ import (
 // ScanForFlags checks the configured directory for flags based on the options configured for Code References.
 // flagKeys is a map of flag keys per-project
 func ScanForFlags(opts options.Options, flagKeys map[string][]string, dir string) (Matcher, []ld.ReferenceHunksRep) {
-	matcher := NewMatcher(opts, flagKeys, dir)
+	matcher := NewMultiProjectMatcher(opts, flagKeys, dir)
 
 	refs, err := SearchForRefs(dir, matcher)
 	if err != nil {

--- a/search/scan.go
+++ b/search/scan.go
@@ -1,0 +1,49 @@
+package search
+
+import (
+	"strings"
+
+	"github.com/launchdarkly/ld-find-code-refs/v2/aliases"
+	"github.com/launchdarkly/ld-find-code-refs/v2/flags"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/helpers"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/ld"
+	"github.com/launchdarkly/ld-find-code-refs/v2/internal/log"
+	"github.com/launchdarkly/ld-find-code-refs/v2/options"
+)
+
+// ScanForFlags checks the configured directory for flags based on the options configured for Code References.
+// flagKeys is a map of flag keys per-project
+func ScanForFlags(opts options.Options, flagKeys map[string][]string, dir string) (Matcher, []ld.ReferenceHunksRep) {
+	elements := []ElementMatcher{}
+
+	for _, project := range opts.Projects {
+		projectFlags := flagKeys[project.Key]
+		projectAliases := opts.Aliases
+		projectAliases = append(projectAliases, project.Aliases...)
+		aliasesByFlagKey, err := aliases.GenerateAliases(projectFlags, projectAliases, dir)
+		if err != nil {
+			log.Error.Fatalf("failed to generate aliases: %s for project: %s", err, project.Key)
+		}
+
+		delimiters := strings.Join(helpers.Dedupe(getDelimiters(opts)), "")
+		elements = append(elements, NewElementMatcher(project.Key, project.Dir, delimiters, projectFlags, aliasesByFlagKey))
+	}
+	matcher := Matcher{
+		ctxLines: opts.ContextLines,
+		Elements: elements,
+	}
+
+	refs, err := SearchForRefs(dir, matcher)
+	if err != nil {
+		log.Error.Fatalf("error searching for flag key references: %s", err)
+	}
+
+	return matcher, refs
+}
+
+// Scan checks the configured directory for flags based on the options configured for Code References.
+// @Deprecated: Use ScanForFlags instead
+func Scan(opts options.Options, repoParams ld.RepoParams, dir string) (Matcher, []ld.ReferenceHunksRep) {
+	flagKeys := flags.GetFlagKeys(opts, repoParams)
+	return ScanForFlags(opts, flagKeys, dir)
+}

--- a/search/scan.go
+++ b/search/scan.go
@@ -7,9 +7,9 @@ import (
 	"github.com/launchdarkly/ld-find-code-refs/v2/options"
 )
 
-// ScanForFlags checks the configured directory for flags based on the options configured for Code References.
-// flagKeys is a map of flag keys per-project
-func ScanForFlags(opts options.Options, flagKeys map[string][]string, dir string) (Matcher, []ld.ReferenceHunksRep) {
+// Scan checks the configured directory for flags based on the options configured for Code References.
+func Scan(opts options.Options, repoParams ld.RepoParams, dir string) (Matcher, []ld.ReferenceHunksRep) {
+	flagKeys := flags.GetFlagKeys(opts, repoParams)
 	matcher := NewMultiProjectMatcher(opts, dir, flagKeys)
 
 	refs, err := SearchForRefs(dir, matcher)
@@ -18,11 +18,4 @@ func ScanForFlags(opts options.Options, flagKeys map[string][]string, dir string
 	}
 
 	return matcher, refs
-}
-
-// Scan checks the configured directory for flags based on the options configured for Code References.
-// @Deprecated: Use ScanForFlags instead
-func Scan(opts options.Options, repoParams ld.RepoParams, dir string) (Matcher, []ld.ReferenceHunksRep) {
-	flagKeys := flags.GetFlagKeys(opts, repoParams)
-	return ScanForFlags(opts, flagKeys, dir)
 }

--- a/search/scan.go
+++ b/search/scan.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/launchdarkly/ld-find-code-refs/v2/aliases"
 	"github.com/launchdarkly/ld-find-code-refs/v2/flags"
-	"github.com/launchdarkly/ld-find-code-refs/v2/internal/helpers"
 	"github.com/launchdarkly/ld-find-code-refs/v2/internal/ld"
 	"github.com/launchdarkly/ld-find-code-refs/v2/internal/log"
 	"github.com/launchdarkly/ld-find-code-refs/v2/options"
@@ -25,7 +24,7 @@ func ScanForFlags(opts options.Options, flagKeys map[string][]string, dir string
 			log.Error.Fatalf("failed to generate aliases: %s for project: %s", err, project.Key)
 		}
 
-		delimiters := strings.Join(helpers.Dedupe(getDelimiters(opts)), "")
+		delimiters := strings.Join(GetDelimiters(opts), "")
 		elements = append(elements, NewElementMatcher(project.Key, project.Dir, delimiters, projectFlags, aliasesByFlagKey))
 	}
 	matcher := Matcher{

--- a/search/scan.go
+++ b/search/scan.go
@@ -10,7 +10,7 @@ import (
 // ScanForFlags checks the configured directory for flags based on the options configured for Code References.
 // flagKeys is a map of flag keys per-project
 func ScanForFlags(opts options.Options, flagKeys map[string][]string, dir string) (Matcher, []ld.ReferenceHunksRep) {
-	matcher := NewMultiProjectMatcher(opts, flagKeys, dir)
+	matcher := NewMultiProjectMatcher(opts, dir, flagKeys)
 
 	refs, err := SearchForRefs(dir, matcher)
 	if err != nil {

--- a/search/scan.go
+++ b/search/scan.go
@@ -1,9 +1,6 @@
 package search
 
 import (
-	"strings"
-
-	"github.com/launchdarkly/ld-find-code-refs/v2/aliases"
 	"github.com/launchdarkly/ld-find-code-refs/v2/flags"
 	"github.com/launchdarkly/ld-find-code-refs/v2/internal/ld"
 	"github.com/launchdarkly/ld-find-code-refs/v2/internal/log"
@@ -13,24 +10,7 @@ import (
 // ScanForFlags checks the configured directory for flags based on the options configured for Code References.
 // flagKeys is a map of flag keys per-project
 func ScanForFlags(opts options.Options, flagKeys map[string][]string, dir string) (Matcher, []ld.ReferenceHunksRep) {
-	elements := []ElementMatcher{}
-
-	for _, project := range opts.Projects {
-		projectFlags := flagKeys[project.Key]
-		projectAliases := opts.Aliases
-		projectAliases = append(projectAliases, project.Aliases...)
-		aliasesByFlagKey, err := aliases.GenerateAliases(projectFlags, projectAliases, dir)
-		if err != nil {
-			log.Error.Fatalf("failed to generate aliases: %s for project: %s", err, project.Key)
-		}
-
-		delimiters := strings.Join(GetDelimiters(opts), "")
-		elements = append(elements, NewElementMatcher(project.Key, project.Dir, delimiters, projectFlags, aliasesByFlagKey))
-	}
-	matcher := Matcher{
-		ctxLines: opts.ContextLines,
-		Elements: elements,
-	}
+	matcher := NewMatcher(opts, flagKeys, dir)
 
 	refs, err := SearchForRefs(dir, matcher)
 	if err != nil {


### PR DESCRIPTION
Reorg package to make it easier to understand.

Expose delimiters function and dedupe returned list.
Expose a function to make multi-project matcher from config (this is used for multi-repo support)

No functional or breaking changes.