### PR TITLE
chore: Add release version to commit message

### DIFF
--- a/.ldrelease/publish-bitbucket-metadata.sh
+++ b/.ldrelease/publish-bitbucket-metadata.sh
@@ -17,7 +17,7 @@ cd bitbucketMetadataUpdates
 git config user.email "launchdarklyreleasebot@launchdarkly.com"
 git config user.name "LaunchDarklyReleaseBot"
 git add -u
-git commit -m "Release auto update version"
+git commit -m "Release auto update version $RELEASE_VERSION"
 git remote add bb-origin "https://${BITBUCKET_USERNAME}:${BITBUCKET_TOKEN}@bitbucket.org/launchdarkly/ld-find-code-refs-pipe.git"
 
 if [[ -z "${LD_RELEASE_DRY_RUN}" ]]; then

--- a/.ldrelease/publish-github-actions-metadata.sh
+++ b/.ldrelease/publish-github-actions-metadata.sh
@@ -9,6 +9,10 @@ RELEASE_TAG="v${RELEASE_VERSION}"
 GITHUB_TOKEN=${2:-"${LD_RELEASE_SECRETS_DIR}/github_token"}
 RELEASE_NOTES="$(make echo-release-notes)"
 
+# All users of github action to reference major version tag
+VERSION_MAJOR="${RELEASE_VERSION%%\.*}"
+RELEASE_TAG_MAJOR="v${VERSION_MAJOR}"
+
 # install gh cli so we can create a release later https://github.com/cli/cli/blob/trunk/docs/install_linux.md
 curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
@@ -36,6 +40,8 @@ if [[ -z "${LD_RELEASE_DRY_RUN}" ]]; then
   # tag the commit with the release version and create release
   git tag $RELEASE_TAG
   git push origin main --tags
+  git tag -f $RELEASE_TAG_MAJOR
+  git push -f origin $RELEASE_TAG_MAJOR
   gh release create $RELEASE_TAG --notes "$RELEASE_NOTES"
 else
   echo "Dry run: will not publish action to github action marketplace."

--- a/.ldrelease/publish-github-actions-metadata.sh
+++ b/.ldrelease/publish-github-actions-metadata.sh
@@ -28,7 +28,7 @@ cd githubActionsMetadataUpdates
 git config user.email "launchdarklyreleasebot@launchdarkly.com"
 git config user.name "LaunchDarklyReleaseBot"
 git add -u
-git commit -m "Release auto update version"
+git commit -m "Release auto update version $RELEASE_VERSION"
 
 if [[ -z "${LD_RELEASE_DRY_RUN}" ]]; then
   echo "Live run: will publish action to github action marketplace."


### PR DESCRIPTION
Make it easier when looking at commit messages to tell what version was being released

Also, create a major version tag which will allow users to get minor updates without manually updating their action file

```yaml
- uses: launchdarkly/find-code-references@v2
```