### PR TITLE
fix(#429): Multi-project scans now ignore projects without valid flags

### DIFF
--- a/flags/flags.go
+++ b/flags/flags.go
@@ -2,7 +2,6 @@ package flags
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/launchdarkly/ld-find-code-refs/v2/internal/helpers"
 	"github.com/launchdarkly/ld-find-code-refs/v2/internal/ld"
@@ -32,18 +31,8 @@ func GetFlagKeys(opts options.Options, repoParams ld.RepoParams) map[string][]st
 		if err != nil {
 			helpers.FatalServiceError(fmt.Errorf("could not retrieve flag keys from LaunchDarkly for project `%s`: %w", proj.Key, err), ignoreServiceErrors)
 		}
-
-		filteredFlags, omittedFlags := filterShortFlagKeys(flags)
-		if len(filteredFlags) == 0 {
-			log.Info.Printf("no flag keys longer than the minimum flag key length (%v) were found for project: %s, exiting early",
-				minFlagKeyLen, proj.Key)
-			os.Exit(0)
-		} else if len(omittedFlags) > 0 {
-			log.Warning.Printf("omitting %d flags with keys less than minimum (%d) for project: %s", len(omittedFlags), minFlagKeyLen, proj.Key)
-		}
-		flagKeys[proj.Key] = filteredFlags
+		addFlagKeys(flagKeys, flags, proj.Key)
 	}
-
 	return flagKeys
 }
 
@@ -60,6 +49,18 @@ func filterShortFlagKeys(flags []string) (filtered []string, omitted []string) {
 		}
 	}
 	return filteredFlags, omittedFlags
+}
+
+func addFlagKeys(flagKeys map[string][]string, flags []string, projKey string) {
+	filteredFlags, omittedFlags := filterShortFlagKeys(flags)
+	if len(filteredFlags) == 0 {
+		log.Warning.Printf("no flag keys longer than the minimum flag key length (%v) were found for project: %s. Skipping project",
+			minFlagKeyLen, projKey)
+		return
+	} else if len(omittedFlags) > 0 {
+		log.Warning.Printf("omitting %d flags with keys less than minimum (%d) for project: %s", len(omittedFlags), minFlagKeyLen, projKey)
+	}
+	flagKeys[projKey] = filteredFlags
 }
 
 func getFlags(ldApi ld.ApiClient, projKey string) ([]string, error) {

--- a/flags/flags_test.go
+++ b/flags/flags_test.go
@@ -53,3 +53,64 @@ func Test_filterShortFlags(t *testing.T) {
 		})
 	}
 }
+
+func Test_addFlagKeys(t *testing.T) {
+	// Note: these specs assume minFlagKeyLen is 3
+	tests := []struct {
+		name     string
+		flagKeys map[string][]string
+		flags    []string
+		projKey  string
+		want     map[string][]string
+	}{
+		{
+			name:     "With a project that contains no flags",
+			flags:    []string{},
+			projKey:  "test_project_1",
+			flagKeys: map[string][]string{},
+			want:     map[string][]string{},
+		},
+		{
+			name:     "With a project that contains no flags and already existing keys",
+			flags:    []string{},
+			projKey:  "test_project_1",
+			flagKeys: map[string][]string{"test_project_2": {"test_key"}},
+			want:     map[string][]string{"test_project_2": {"test_key"}},
+		},
+		{
+			name:     "With a project that contains a flag and already existing keys",
+			flags:    []string{"test_project_key"},
+			projKey:  "test_project_1",
+			flagKeys: map[string][]string{"test_project_2": {"test_key"}},
+			want:     map[string][]string{"test_project_2": {"test_key"}, "test_project_1": {"test_project_key"}},
+		},
+		{
+			name:     "With a project that contains multiple flags and already existing keys",
+			flags:    []string{"test_project_key", "test_project_key_2"},
+			projKey:  "test_project_1",
+			flagKeys: map[string][]string{"test_project_2": {"test_key"}},
+			want:     map[string][]string{"test_project_2": {"test_key"}, "test_project_1": {"test_project_key", "test_project_key_2"}},
+		},
+		{
+			name:     "With a project that contains a short and log flags",
+			flags:    []string{"test_project_key", "t"},
+			projKey:  "test_project_1",
+			flagKeys: map[string][]string{"test_project_2": {"test_key"}},
+			want:     map[string][]string{"test_project_2": {"test_key"}, "test_project_1": {"test_project_key"}},
+		},
+		{
+			name:     "With a project that contains a short flag",
+			flags:    []string{"k"},
+			projKey:  "test_project_1",
+			flagKeys: map[string][]string{"test_project_2": {"test_key"}},
+			want:     map[string][]string{"test_project_2": {"test_key"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			addFlagKeys(tt.flagKeys, tt.flags, tt.projKey)
+			require.Equal(t, tt.want, tt.flagKeys)
+		})
+	}
+}


### PR DESCRIPTION
### Description

- Addresses issue #429.
- Projects without invalid flags will be ignored. A log message is written when this occurs.