### PR TITLE
feat: don't skip .github dir

### DIFF
--- a/search/files.go
+++ b/search/files.go
@@ -82,6 +82,10 @@ func readFiles(ctx context.Context, files chan<- file, workspace string) error {
 		// Skip directories, hidden files, and ignored files
 		if strings.HasPrefix(info.Name(), ".") || allIgnores.Match(path, isDir) {
 			if isDir {
+				// don't skip github dir
+				if strings.HasPrefix(info.Name(), ".github") {
+					return nil
+				}
 				return filepath.SkipDir
 			}
 			return nil

--- a/search/files_test.go
+++ b/search/files_test.go
@@ -18,7 +18,7 @@ func Test_readFiles(t *testing.T) {
 		switch file.path {
 		case "fileWithNoRefs":
 			assert.Equal(t, []string{"fileWithNoRefs"}, file.lines)
-		case "fileWithRefs":
+		case "fileWithRefs", ".github/workflows/workflow.yml":
 			assert.Equal(t, testFile.lines, file.lines)
 		case "ignoredFiles/included":
 			assert.Equal(t, []string{"IGNORED BUT INCLUDED"}, file.lines)
@@ -28,5 +28,5 @@ func Test_readFiles(t *testing.T) {
 			assert.Fail(t, "Read unexpected file", file)
 		}
 	}
-	assert.Len(t, got, 3, "Expected 3 valid files to have been found")
+	assert.Len(t, got, 4, "Expected 4 valid files to have been found")
 }

--- a/search/testdata/.github/workflows/workflow.yml
+++ b/search/testdata/.github/workflows/workflow.yml
@@ -1,0 +1,5 @@
+someFlag
+anotherFlag
+someFlaganotherFlag
+some-flag
+another-flag


### PR DESCRIPTION
allow scanning for flag keys used in github workflows with https://github.com/launchdarkly/gha-flags

User will need to have delimiters turned off or use proper aliasing to pick them up