### PR TITLE
account for subdirectory in ref filepaths

### DIFF
--- a/search/files_test.go
+++ b/search/files_test.go
@@ -11,7 +11,7 @@ import (
 func Test_readFiles(t *testing.T) {
 	t.Run("don't ignore .github by default", func(t *testing.T) {
 		files := make(chan file, 8)
-		err := readFiles(context.Background(), files, "testdata/include-github-files")
+		err := readFiles(context.Background(), files, "testdata/include-github-files", "")
 		require.NoError(t, err)
 		got := []file{}
 		for file := range files {
@@ -34,7 +34,7 @@ func Test_readFiles(t *testing.T) {
 
 	t.Run("explicitly ignore .github files", func(t *testing.T) {
 		files := make(chan file, 8)
-		err := readFiles(context.Background(), files, "testdata/exclude-github-files")
+		err := readFiles(context.Background(), files, "testdata/exclude-github-files", "")
 		require.NoError(t, err)
 		got := []file{}
 		for file := range files {

--- a/search/scan.go
+++ b/search/scan.go
@@ -19,7 +19,7 @@ func Scan(opts options.Options, repoParams ld.RepoParams, dir string) (Matcher, 
 		searchDir = filepath.Join(dir, opts.Subdirectory)
 	}
 
-	refs, err := SearchForRefs(searchDir, matcher)
+	refs, err := SearchForRefs(searchDir, opts.Subdirectory, matcher)
 	if err != nil {
 		log.Error.Fatalf("error searching for flag key references: %s", err)
 	}

--- a/search/search.go
+++ b/search/search.go
@@ -104,6 +104,7 @@ func (f file) aggregateHunksForFlag(projKey, flagKey string, matcher Matcher, li
 func (f file) toHunks(matcher Matcher) *ld.ReferenceHunksRep {
 	hunks := make([]ld.HunkRep, 0)
 	filteredMatchers := make([]ElementMatcher, 0)
+
 	for _, elementSearch := range matcher.Elements {
 		if elementSearch.Dir != "" {
 			matchDir := strings.HasPrefix(f.path, elementSearch.Dir)
@@ -192,7 +193,7 @@ func processFiles(ctx context.Context, files <-chan file, references chan<- ld.R
 	w.Wait()
 }
 
-func SearchForRefs(directory string, matcher Matcher) ([]ld.ReferenceHunksRep, error) {
+func SearchForRefs(directory, subdirectory string, matcher Matcher) ([]ld.ReferenceHunksRep, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	files := make(chan file)
@@ -200,7 +201,7 @@ func SearchForRefs(directory string, matcher Matcher) ([]ld.ReferenceHunksRep, e
 	// Start workers to process files asynchronously as they are written to the files channel
 	go processFiles(ctx, files, references, matcher)
 
-	err := readFiles(ctx, files, directory)
+	err := readFiles(ctx, files, directory, subdirectory)
 	if err != nil {
 		return nil, err
 	}

--- a/search/search_test.go
+++ b/search/search_test.go
@@ -394,7 +394,7 @@ func Test_SearchForRefs(t *testing.T) {
 		NewElementMatcher("default", "", "", []string{testFlagKey, testFlagKey2}, nil),
 	)
 	t.Cleanup(func() { os.Remove("testdata/exclude-github-files/symlink") })
-	got, err := SearchForRefs("testdata/exclude-github-files", matcher)
+	got, err := SearchForRefs("testdata/exclude-github-files", "", matcher)
 	require.NoError(t, err)
 	require.Len(t, got, 1)
 	require.Equal(t, want[0].Path, got[0].Path)


### PR DESCRIPTION
We were inadverntently ignoring the `subdirectory` option when creating `File` reps, which led to the tool search zero files when using the project-level `dir` property in `.launchdarkly/coderefs.yml`. The reason for this is that when using the `subdirectory` property, the `workspace` (this is the root directory that `ld-find-code-refs` searches under) becomes `<root>/subdirectory`, but the project-level `dir` property is relative to the repo root, so the tool would end up looking in `<root>/subdirectory/subdirectory` for files to scan which obviously doesn't exist. The fix here is to remove the `subdirectory` (if it exists) from  the `file`'s `path` property. Existing tests pass. New tests for the `subdirectory` use-case in progress, so I'll leave in draft for now.