### PR TITLE
[REL-4161] add logic to update the changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
     env:
       LD_RELEASE_VERSION: ${{ inputs.releaseVersion }}
       DRY_RUN: ${{ inputs.dryRun || 'false' }}
+      CHANGELOG_ENTRY: ${{ inputs.changeLog }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       ARTIFACT_DIRECTORY: "/tmp/release-artifacts"
     steps:

--- a/scripts/release/commit-and-tag.sh
+++ b/scripts/release/commit-and-tag.sh
@@ -9,16 +9,34 @@ tag_exists() (
   git rev-parse "${RELEASE_TAG}" >/dev/null 2>&1
 )
 
+update_changelog() (
+  local ts=$(date +"%Y-%m-%d"))
+  local changelog_entry=$(cat << EOF
+## [$LD_RELEASE_VERSION] - $ts
+$CHANGELOG_ENTRY
+EOF
+  )
+
+  # insert the new changelog entry (followed by empty line) after line 4
+  # of CHANGELOG.md
+  sed -i "4r /dev/stdin" CHANGELOG.md <<< "$changelog_entry"$'\n'
+
+  cat CHANGELOG.md
+)
+
 echo "Changes staged for release $RELEASE_TAG:"
 git diff
 
 if [[ "$DRY_RUN" == "true" ]]; then
   echo "Dry run mode: skipping commit, tag, and push"
+  update_changelog
 else
   if tag_exists; then
     echo "Tag $RELEASE_TAG already exists. Aborting."
     exit 1
   fi
+
+  update_changelog
 
   git config user.name "LaunchDarklyReleaseBot"
   git config user.email "releasebot@launchdarkly.com"


### PR DESCRIPTION
Another follow up for the migration to GHA from Releaser for this repo.
Releaser took care of updating the changelog, and I missed that I would need to include that in the GHA as well. The update will take place only after the release of the GHA, CircleCI Orb and BitBucket Pipe have completed successfully.
<!-- ld-jira-link -->
---
Related Jira issue: [REL-4161: Migrate ld-find-code-refs from Releaser to GHA](https://launchdarkly.atlassian.net/browse/REL-4161)
<!-- end-ld-jira-link -->