### PR TITLE
[REL-4161] switch to printf to allow for backticks in CHANGELOG

### DIFF
--- a/scripts/release/commit-and-tag.sh
+++ b/scripts/release/commit-and-tag.sh
@@ -11,10 +11,7 @@ tag_exists() (
 
 update_changelog() (
   local ts=$(date +"%Y-%m-%d")
-  local changelog_entry=$(cat << EOF
-## [$LD_RELEASE_VERSION] - $ts
-$CHANGELOG_ENTRY
-EOF
+  local changelog_entry=$(printf "## [%s] - %s\n%s\n" "$LD_RELEASE_VERSION" "$ts" "$CHANGELOG_ENTRY")
 
   # insert the new changelog entry (followed by empty line) after line 4
   # of CHANGELOG.md


### PR DESCRIPTION
😩 please let this be the last one 😩

Using the heredoc was creating toil because the syntax is kinda fiddly and `workflow_dispatch` is only available on main, so I needed to create a PR and get a review for every change. But in the end, using `printf` is better anyway because it allows for backticks, which bash will try to run if they appear inside an unquoted heredoc. We'll see if the CHANGELOG comes out looking okay, but cursor assures me `printf` works well for multiline content. 🤞 
<!-- ld-jira-link -->
---
Related Jira issue: [REL-4161: Migrate ld-find-code-refs from Releaser to GHA](https://launchdarkly.atlassian.net/browse/REL-4161)
<!-- end-ld-jira-link -->