### PR TITLE
chore: [REL-4161] get changelog working with escaped string

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
         required: true
         type: string
       changeLog:
-        description: Pending changelog
+        description: Pending changelog (for now please escape new lines; will fix)
         required: true
         type: string
 

--- a/scripts/release/commit-and-tag.sh
+++ b/scripts/release/commit-and-tag.sh
@@ -11,7 +11,12 @@ tag_exists() (
 
 update_changelog() (
   local ts=$(date +"%Y-%m-%d")
-  local changelog_entry=$(printf "## [%s] - %s\n%s\n" "$LD_RELEASE_VERSION" "$ts" "$CHANGELOG_ENTRY")
+  # multiline strings don't seem to be supported for GHA inputs, so for now we
+  # require that the changelog include \n characters for new lines and then we
+  # just expand them here
+  # TODO improve this
+  local changelog_content=$(printf "%b" "$CHANGELOG_ENTRY")
+  local changelog_entry=$(printf "## [%s] - %s\n%s\n" "$LD_RELEASE_VERSION" "$ts" "$changelog_content")
 
   # insert the new changelog entry (followed by empty line) after line 4
   # of CHANGELOG.md


### PR DESCRIPTION
This update will fix the gross changelog formatting as long as the GHA changelog input is a single-line string with `\n` characters for new lines. Tested this out and it works.

<!-- ld-jira-link -->
---
Related Jira issue: [REL-4161: Migrate ld-find-code-refs from Releaser to GHA](https://launchdarkly.atlassian.net/browse/REL-4161)
<!-- end-ld-jira-link -->