### PR TITLE
move tag creation above goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,8 +65,8 @@ jobs:
         run: |
           git show -p
           ls -1a "$ARTIFACT_DIRECTORY"
-      - name: create tag
-        run: ./scripts/release/create-tag.sh
+      - name: push to origin
+        run: ./scripts/release/push-to-origin.sh
       - name: create Github release
         uses: ncipollo/release-action@v1.14.0
         if: ${{ !inputs.dryRun }}

--- a/scripts/release/prepare-release.sh
+++ b/scripts/release/prepare-release.sh
@@ -37,13 +37,16 @@ update_changelog() (
   sed -i "4r /dev/stdin" CHANGELOG.md <<< "$changelog_entry"$'\n'
 )
 
+# update metadata files and CHANGELOG
 update_go
 update_orb
 update_gha
 update_bitbucket
 update_changelog
 
+# commit changes and create tag
 git config user.name "LaunchDarklyReleaseBot"
 git config user.email "releasebot@launchdarkly.com"
 git add .
 git commit -m "Prepare release ${release_tag}"
+git tag "${release_tag}"

--- a/scripts/release/push-to-origin.sh
+++ b/scripts/release/push-to-origin.sh
@@ -9,21 +9,21 @@ tag_exists() (
   git rev-parse "${release_tag}" >/dev/null 2>&1
 )
 
-create_tag() (
+push_to_origin() (
   if tag_exists; then
     echo "Tag $release_tag already exists. Aborting."
     exit 1
   fi
 
-  git tag "${release_tag}"
   git push origin HEAD
   git push origin "${release_tag}"
 )
 
 if [[ "$DRY_RUN" == "true" ]]; then
-  git reset --hard HEAD^
-  echo "Dry run mode: skipping tag and push"
+  git tag -d "$release_tag" # defensive
+  git reset --hard HEAD^    # defensive
+  echo "Dry run mode: skipping push"
 else
-  create_tag
+  push_to_origin
 fi
 


### PR DESCRIPTION
I thought goreleaser would pull the version from `internal/version/version.go`, and so I though updating that with the new version and committing the change would suffice, but turns out (at least, I think) goreleaser is actually pulling the latest tag that matches a version regexp. So this update creates the tag as well before running goreleaser.