### PR TITLE
chore: [REL-4161] add homebre-tap to repo_keys_map

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,8 @@ jobs:
         with:
           repo_keys_map: |
             {
-              "launchdarkly/find-code-references": ${{ toJSON(secrets.LAUNCHDARKLY_FIND_CODE_REFERENCES_DEPLOY_KEY) }}
+              "launchdarkly/find-code-references": ${{ toJSON(secrets.LAUNCHDARKLY_FIND_CODE_REFERENCES_DEPLOY_KEY) }},
+              "launchdarkly/homebrew-tap": ${{ toJSON(secrets.LAUNCHDARKLY_HOMEBREW_TAP_DEPLOY_KEY) }}
             }
       - name: build
         run: |


### PR DESCRIPTION
This repo needs to access launchdarkly/homebrew-tap. See error [here](https://github.com/launchdarkly/ld-find-code-refs/actions/runs/16570352835/job/46860634653#step:7:642). Corresponding [terraform update](https://github.com/launchdarkly/terraform/pull/19909) (needs to be merged first). 
<!-- ld-jira-link -->
---
Related Jira issue: [REL-4161: Migrate ld-find-code-refs from Releaser to GHA](https://launchdarkly.atlassian.net/browse/REL-4161)
<!-- end-ld-jira-link -->