### PR TITLE
chore: [REL-4161] thread homebrew-tap deploy key through to goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
       DRY_RUN: ${{ inputs.dryRun || 'false' }}
       CHANGELOG_ENTRY: ${{ inputs.changeLog }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      HOMEBREW_GH_TOKEN: ${{ toJSON(secrets.LAUNCHDARKLY_HOMEBREW_TAP_DEPLOY_KEY) }}
       ARTIFACT_DIRECTORY: "/tmp/release-artifacts"
     steps:
       - uses: actions/checkout@v4
@@ -43,7 +44,6 @@ jobs:
           repo_keys_map: |
             {
               "launchdarkly/find-code-references": ${{ toJSON(secrets.LAUNCHDARKLY_FIND_CODE_REFERENCES_DEPLOY_KEY) }},
-              "launchdarkly/homebrew-tap": ${{ toJSON(secrets.LAUNCHDARKLY_HOMEBREW_TAP_DEPLOY_KEY) }}
             }
       - name: build
         run: |

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,5 @@
 builds:
-  -
-    binary: ld-find-code-refs
+  - binary: ld-find-code-refs
     id: ld-find-code-refs
     main: ./cmd/ld-find-code-refs/
     env:
@@ -13,12 +12,10 @@ builds:
       - 386
       - amd64
       - arm64
-
     ignore:
       - goos: darwin
         goarch: 386
-  -
-    binary: ld-find-code-refs-github-action
+  - binary: ld-find-code-refs-github-action
     id: ld-find-code-refs-github-action
     main: ./build/package/github-actions/
     env:
@@ -27,8 +24,7 @@ builds:
       - linux
     goarch:
       - amd64
-  -
-    binary: ld-find-code-refs-bitbucket-pipeline
+  - binary: ld-find-code-refs-bitbucket-pipeline
     id: ld-find-code-refs-bitbucket-pipeline
     main: ./build/package/bitbucket-pipelines/
     env:
@@ -39,26 +35,22 @@ builds:
       - amd64
 
 archives:
-  -
-    id: ld-find-code-refs
+  - id: ld-find-code-refs
     builds:
       - ld-find-code-refs
 
 nfpms:
-  -
-    id: ld-find-code-refs
+  - id: ld-find-code-refs
     file_name_template: >-
       {{- .ProjectName -}}_
       {{- .Version -}}.
       {{- if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end -}}
-
     homepage: https://launchdarkly.com/
     maintainer: LaunchDarkly <team@launchdarkly.com>
     description: Job for finding and sending feature flag code references to LaunchDarkly
     license: Apache 2.0
     vendor: LaunchDarkly
-
     formats:
       - deb
       - rpm
@@ -73,7 +65,7 @@ brews:
       branch: main
       git:
         url: git@github.com:launchdarkly/homebrew-tap.git
-        private_key: "{{ .Env.LAUNCHDARKLY_HOMEBREW_TAP_DEPLOY_KEY }}"
+        private_key: "{{ .Env.HOMEBREW_GH_TOKEN }}"
     directory: Formula
     url_template: "https://github.com/launchdarkly/ld-find-code-refs/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
     install: |
@@ -83,18 +75,14 @@ brews:
       email: launchdarklyreleasebot@launchdarkly.com
 
 release:
-  disable: true # this disables releasing *to GitHub*; it will still push to Docker
-  # (we want Releaser to be responsible for doing all the GitHub release manipulations)
+  disable: true # the release GHA takes care of releasing to Github
 
 dockers:
-  -
-    image_templates:
+  - image_templates:
       - "launchdarkly/ld-find-code-refs:latest"
       - "launchdarkly/ld-find-code-refs:{{ .Version }}"
     dockerfile: Dockerfile
-  -
-    goos: linux
-    # GOARCH of the built binaries/packages that should be used.
+  - goos: linux # GOARCH of the built binaries/packages that should be used.
     goarch: amd64
     ids:
       - ld-find-code-refs-github-action
@@ -102,9 +90,7 @@ dockers:
       - "launchdarkly/ld-find-code-refs-github-action:latest"
       - "launchdarkly/ld-find-code-refs-github-action:{{ .Version }}"
     dockerfile: Dockerfile.github
-  -
-    goos: linux
-    # GOARCH of the built binaries/packages that should be used.
+  - goos: linux # GOARCH of the built binaries/packages that should be used.
     goarch: amd64
     ids:
       - ld-find-code-refs-bitbucket-pipeline

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ clean:
 	rm -f build/package/github-actions/ld-find-code-refs-github-action
 	rm -f build/package/bitbucket-pipelines/ld-find-code-refs-bitbucket-pipeline
 
-RELEASE_CMD=curl -sL https://git.io/goreleaser | GOPATH=$(mktemp -d) VERSION=$(GORELEASER_VERSION) GITHUB_TOKEN=$(GITHUB_TOKEN) LAUNCHDARKLY_HOMEBREW_TAP_DEPLOY_KEY=${LAUNCHDARKLY_HOMEBREW_TAP_DEPLOY_KEY} bash -s -- --clean --debug --release-notes $(RELEASE_NOTES)
+RELEASE_CMD=curl -sL https://git.io/goreleaser | GOPATH=$(mktemp -d) VERSION=$(GORELEASER_VERSION) GITHUB_TOKEN=$(GITHUB_TOKEN) bash -s -- --clean --debug --release-notes $(RELEASE_NOTES)
 
 publish:
 	$(RELEASE_CMD)


### PR DESCRIPTION
I think we need to add the `LAUNCHDARKLY_HOMEBREW_TAP_DEPLOY_KEY` as an env var in order to make it available to goreleaser. I think the reason this didn't work with the `ssh_key_by_repo` action is because the GHA itself is not accessing the homebrew-tap repo; it's goreleaser that's trying to make changes there. However, since we added `homebrew-tap` as a `cross_repo_deploy_key` for `ld-find-code-refs`, I believe the secret lives on the repo (see the description in screenshot), so I'm hopeful grabbing it from `secrets` and setting as an env var will be enough to give access to goreleaser.

<img width="1579" height="240" alt="Screenshot 2025-08-04 at 1 29 55 PM" src="https://github.com/user-attachments/assets/5131563e-f3c4-42ab-b58a-50322665fb64" />

<!-- ld-jira-link -->
---
Related Jira issue: [REL-4161: Migrate ld-find-code-refs from Releaser to GHA](https://launchdarkly.atlassian.net/browse/REL-4161)
<!-- end-ld-jira-link -->