### PR TITLE
chore: [REL-4161] remove trailing comma

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           repo_keys_map: |
             {
-              "launchdarkly/find-code-references": ${{ toJSON(secrets.LAUNCHDARKLY_FIND_CODE_REFERENCES_DEPLOY_KEY) }},
+              "launchdarkly/find-code-references": ${{ toJSON(secrets.LAUNCHDARKLY_FIND_CODE_REFERENCES_DEPLOY_KEY) }}
             }
       - name: build
         run: |


### PR DESCRIPTION
Missed a trailing comma that's causing things to blow up.
<!-- ld-jira-link -->
---
Related Jira issue: [REL-4161: Migrate ld-find-code-refs from Releaser to GHA](https://launchdarkly.atlassian.net/browse/REL-4161)
<!-- end-ld-jira-link -->