### PR TITLE
update goreleaser config for version 1.20

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -57,6 +57,8 @@ nfpms:
 
 brews:
   - name: ld-find-code-refs
+    ids:
+      - ld-find-code-refs
     description: Job for finding and sending feature flag code references to LaunchDarkly
     homepage: "https://launchdarkly.com"
     repository:
@@ -66,7 +68,7 @@ brews:
       git:
         url: git@github.com:launchdarkly/homebrew-tap.git
         private_key: "{{ .Env.HOMEBREW_GH_TOKEN }}"
-    directory: Formula
+    folder: Formula
     url_template: "https://github.com/launchdarkly/ld-find-code-refs/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
     install: |
       bin.install "ld-find-code-refs"


### PR DESCRIPTION
Apparently, the config properties have changed over time, and `directory` used to be called `folder`. Docs for GoReleaser 1.20 can be found [here](https://github.com/goreleaser/goreleaser/blob/v1.20.0/www/docs/customization/homebrew.md). Eventually, it would be good to update the Goreleaser version here, but for now I just want to cut a new release as it's blocking a fair number of improvements, some of which are kinda important.

I had also removed the `ids` property, but I'm adding it back in here. I don't really understand what it's for. The docs say: `IDs of the archives to use`. not sure what that means, but seems like leaving this in for now would make the most sense, since it has existed up until this point.