### PR TITLE
chore: [REL-4161] remove json encoding for homebrew deploy key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       DRY_RUN: ${{ inputs.dryRun || 'false' }}
       CHANGELOG_ENTRY: ${{ inputs.changeLog }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      HOMEBREW_GH_TOKEN: ${{ toJSON(secrets.LAUNCHDARKLY_HOMEBREW_TAP_DEPLOY_KEY) }}
+      HOMEBREW_GH_TOKEN: ${{ secrets.LAUNCHDARKLY_HOMEBREW_TAP_DEPLOY_KEY }}
       ARTIFACT_DIRECTORY: "/tmp/release-artifacts"
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
According to ChatGPT, Goreleaser is complaining because the homebrew deploy key is json-encoded. That makes some sense, so I'm hopeful that the bot is right. The error I got is [here](https://github.com/launchdarkly/ld-find-code-refs/actions/runs/16732042635/job/47362177462#step:7:271).
<!-- ld-jira-link -->
---
Related Jira issue: [REL-4161: Migrate ld-find-code-refs from Releaser to GHA](https://launchdarkly.atlassian.net/browse/REL-4161)
<!-- end-ld-jira-link -->