### PR TITLE
chore: [REL-4161] pass homebrew token through Makefile to Goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
           if [[ "$DRY_RUN" = true ]]; then
             ./scripts/release/publish-dry-run.sh
           else
-            echo ./scripts/release/publish.sh
+            ./scripts/release/publish.sh
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ clean:
 	rm -f build/package/github-actions/ld-find-code-refs-github-action
 	rm -f build/package/bitbucket-pipelines/ld-find-code-refs-bitbucket-pipeline
 
-RELEASE_CMD=curl -sL https://git.io/goreleaser | GOPATH=$(mktemp -d) VERSION=$(GORELEASER_VERSION) GITHUB_TOKEN=$(GITHUB_TOKEN) bash -s -- --clean --debug --release-notes $(RELEASE_NOTES)
+RELEASE_CMD=curl -sL https://git.io/goreleaser | GOPATH=$(mktemp -d) VERSION=$(GORELEASER_VERSION) GITHUB_TOKEN=$(GITHUB_TOKEN) HOMEBREW_GH_TOKEN=$(HOMEBREW_GH_TOKEN) bash -s -- --clean --debug --release-notes $(RELEASE_NOTES)
 
 publish:
 	$(RELEASE_CMD)

--- a/scripts/release/stage-artifacts.sh
+++ b/scripts/release/stage-artifacts.sh
@@ -7,7 +7,7 @@ stage_artifacts() (
 
   echo "$DOCKER_TOKEN" | sudo docker login --username "$DOCKER_USERNAME" --password-stdin
 
-  sudo PATH="$PATH" GITHUB_TOKEN="$GITHUB_TOKEN" make "$target"
+  sudo PATH="$PATH" GITHUB_TOKEN="$GITHUB_TOKEN" HOMEBREW_GH_TOKEN="$HOMEBREW_GH_TOKEN" make "$target"
 
   mkdir -p "$ARTIFACT_DIRECTORY"
   cp ./dist/*.deb ./dist/*.rpm ./dist/*.tar.gz ./dist/*.txt "$ARTIFACT_DIRECTORY"


### PR DESCRIPTION
Okay, I think I finally understand why Goreleaser wasn't able to find the HOMEBREW_GH_TOKEN. Setting it as an env var on the GHA is not enough, it needs to be explicitly passed to the Makefile, and then passed to the Goreleaser command.
<!-- ld-jira-link -->
---
Related Jira issue: [REL-4161: Migrate ld-find-code-refs from Releaser to GHA](https://launchdarkly.atlassian.net/browse/REL-4161)
<!-- end-ld-jira-link -->