### PR TITLE
chore: [REL-4161] write deploy key to file instead of adding contents directly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,9 +62,6 @@ jobs:
           else
             ./scripts/release/publish.sh
           fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          LAUNCHDARKLY_HOMEBREW_TAP_DEPLOY_KEY: ${{ secrets.LAUNCHDARKLY_HOMEBREW_TAP_DEPLOY_KEY }}
       - name: release details
         run: |
           git show -p

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -67,7 +67,7 @@ brews:
       branch: main
       git:
         url: git@github.com:launchdarkly/homebrew-tap.git
-        private_key: "{{ .Env.HOMEBREW_GH_TOKEN }}"
+        private_key: "{{ .Env.HOMEBREW_KEY_PATH }}"
     folder: Formula
     url_template: "https://github.com/launchdarkly/ld-find-code-refs/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
     install: |

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ clean:
 	rm -f build/package/github-actions/ld-find-code-refs-github-action
 	rm -f build/package/bitbucket-pipelines/ld-find-code-refs-bitbucket-pipeline
 
-RELEASE_CMD=curl -sL https://git.io/goreleaser | GOPATH=$(mktemp -d) VERSION=$(GORELEASER_VERSION) GITHUB_TOKEN=$(GITHUB_TOKEN) HOMEBREW_GH_TOKEN=$(HOMEBREW_GH_TOKEN) bash -s -- --clean --debug --release-notes $(RELEASE_NOTES)
+RELEASE_CMD=curl -sL https://git.io/goreleaser | GOPATH=$(mktemp -d) VERSION=$(GORELEASER_VERSION) GITHUB_TOKEN=$(GITHUB_TOKEN) HOMEBREW_KEY_PATH=$(HOMEBREW_KEY_PATH) bash -s -- --clean --debug --release-notes $(RELEASE_NOTES)
 
 publish:
 	$(RELEASE_CMD)

--- a/scripts/release/stage-artifacts.sh
+++ b/scripts/release/stage-artifacts.sh
@@ -7,7 +7,15 @@ stage_artifacts() (
 
   echo "$DOCKER_TOKEN" | sudo docker login --username "$DOCKER_USERNAME" --password-stdin
 
-  sudo PATH="$PATH" GITHUB_TOKEN="$GITHUB_TOKEN" HOMEBREW_GH_TOKEN="$HOMEBREW_GH_TOKEN" make "$target"
+  # write homebrew key to temporary file for Goreleaser
+  if [[ -n "${HOMEBREW_GH_TOKEN:-}" ]]; then
+    HOMEBREW_KEY_PATH="/tmp/homebrew-tap-deploy-key"
+    echo "$HOMEBREW_GH_TOKEN" > "$HOMEBREW_KEY_PATH"
+    chmod 600 "$HOMEBREW_KEY_PATH"
+    export HOMEBREW_KEY_PATH
+  fi
+
+  sudo PATH="$PATH" GITHUB_TOKEN="$GITHUB_TOKEN" HOMEBREW_KEY_PATH="$HOMEBREW_KEY_PATH" make "$target"
 
   mkdir -p "$ARTIFACT_DIRECTORY"
   cp ./dist/*.deb ./dist/*.rpm ./dist/*.tar.gz ./dist/*.txt "$ARTIFACT_DIRECTORY"


### PR DESCRIPTION
Since private keys are multiple lines, it's recommended to write them to a file instead of passing the contents directly to an env variable to avoid escaping issues \n characters being handled incorrectly, etc. Goreleaser supports (and probably prefers) writing private keys to a file, so I'm hopeful this will get us there. Hopefully, the private key is not malformed before writing to the file, but I guess we'll find out 😬.
<!-- ld-jira-link -->
---
Related Jira issue: [REL-4161: Migrate ld-find-code-refs from Releaser to GHA](https://launchdarkly.atlassian.net/browse/REL-4161)
<!-- end-ld-jira-link -->