### PR TITLE
chore: [REL-4161] use printf to ensure we get the exact value for homebrew key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       DRY_RUN: ${{ inputs.dryRun || 'false' }}
       CHANGELOG_ENTRY: ${{ inputs.changeLog }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      HOMEBREW_GH_TOKEN: ${{ toJSON(secrets.LAUNCHDARKLY_HOMEBREW_TAP_DEPLOY_KEY) }}
+      HOMEBREW_GH_TOKEN: ${{ secrets.LAUNCHDARKLY_HOMEBREW_TAP_DEPLOY_KEY }}
       ARTIFACT_DIRECTORY: "/tmp/release-artifacts"
     steps:
       - uses: actions/checkout@v4

--- a/scripts/release/stage-artifacts.sh
+++ b/scripts/release/stage-artifacts.sh
@@ -10,7 +10,7 @@ stage_artifacts() (
   # write homebrew key to temporary file for Goreleaser
   if [[ -n "${HOMEBREW_GH_TOKEN:-}" ]]; then
     HOMEBREW_KEY_PATH="/tmp/homebrew-tap-deploy-key"
-    echo "$HOMEBREW_GH_TOKEN" > "$HOMEBREW_KEY_PATH"
+    printf '%s\n' "$HOMEBREW_GH_TOKEN" > "$HOMEBREW_KEY_PATH"
     chmod 600 "$HOMEBREW_KEY_PATH"
     export HOMEBREW_KEY_PATH
   fi


### PR DESCRIPTION
The saga continues. Last time I got an [error](https://github.com/launchdarkly/ld-find-code-refs/actions/runs/16777430844/job/47506788949#step:7:633) that is likely related to a malformed homebrew-tap deploy key. Giving `printf`, and no json encoding a shot. Hopefully, this will write the unaltered value of the key to the file and we'll be good to go.
<!-- ld-jira-link -->
---
Related Jira issue: [REL-4161: Migrate ld-find-code-refs from Releaser to GHA](https://launchdarkly.atlassian.net/browse/REL-4161)
<!-- end-ld-jira-link -->