### PR TITLE
chore: [REL-4161] dont bomb out if ssh dir exists

### DIFF
--- a/scripts/release/publish.sh
+++ b/scripts/release/publish.sh
@@ -6,7 +6,8 @@ source $(dirname $0)/stage-artifacts.sh
 stage_artifacts publish
 
 # make bitbucket and github known hosts to push successfully
-mkdir -m700 ~/.ssh
+mkdir -p ~/.ssh
+chmod 700 ~/.ssh
 touch ~/.ssh/known_hosts
 chmod 644 ~/.ssh/known_hosts
 ssh-keyscan -t rsa bitbucket.org >> ~/.ssh/known_hosts


### PR DESCRIPTION
Homebrew formula was updated successfully! The GHA bombed out on an unrelated (and easily fixed) problem where the `~/.ssh` folder already existed, but we tried to create it. Just need a `-p` there and we should be good to go. I think this may _actually_ be the last one!

Note: According to cursor, Goreleaser will either compare the binaries of the homebrew formula and determine that they are identical and skip the release, OR it will overwrite the homebrew formula with the new one (which is really just the same one). So in either case, we should be good to go there. I don't expect any weirdness. The rest of the action is idempotent, but it didn't run yet anyway, so no worries there either.
<!-- ld-jira-link -->
---
Related Jira issue: [REL-4161: Migrate ld-find-code-refs from Releaser to GHA](https://launchdarkly.atlassian.net/browse/REL-4161)
<!-- end-ld-jira-link -->