### PR TITLE
chore: [REL-4161] ensure tag is being created in the correct directory

### DIFF
--- a/scripts/release/targets/bitbucket.sh
+++ b/scripts/release/targets/bitbucket.sh
@@ -23,13 +23,13 @@ clean_up_bitbucket() (
 
 publish_bitbucket() (
   setup_bitbucket
-  cd bitbucketMetadataUpdates
 
   if git ls-remote --tags origin "refs/tags/v$LD_RELEASE_VERSION" | grep -q "v$LD_RELEASE_VERSION"; then
     echo "Version exists; skipping publishing BitBucket Pipe"
   else
+    cd bitbucketMetadataUpdates
     echo "Live run: will publish pipe to bitbucket."
-    git tag $LD_RELEASE_VERSION
+    git tag "$LD_RELEASE_VERSION"
     git push bb-origin master --tags
   fi
 

--- a/scripts/release/targets/gha.sh
+++ b/scripts/release/targets/gha.sh
@@ -43,12 +43,14 @@ publish_gha() (
     echo "Version exists; skipping publishing GHA"
   else
     echo "Live run: will publish action to github action marketplace."
+
+    cd githubActionsMetadataUpdates
     # tag the commit with the release version and create release
-    git tag $RELEASE_TAG
+    git tag "$RELEASE_TAG"
     git push origin main --tags
-    git tag -f $RELEASE_TAG_MAJOR
-    git push -f origin $RELEASE_TAG_MAJOR
-    gh release create $RELEASE_TAG --notes "$RELEASE_NOTES"
+    git tag -f "$RELEASE_TAG_MAJOR"
+    git push -f origin "$RELEASE_TAG_MAJOR"
+    gh release create "$RELEASE_TAG" --notes "$RELEASE_NOTES"
   fi
 
   clean_up_gha


### PR DESCRIPTION
There was a missing line here to get into the correct directory. This was just an oversight [^1]. However, the error was quite alarming, and it turns out there's some less-than-ideal git practices here that I'll definitely be cleaning up once I finally get this release out the door. The tl;dr is that we have the main coderefs tool that lives in this repo and we have two other repos that contain the coderefs GHA and the coderefs Bitbucket Pipe. As it happens, we are cloning those repos into directories _inside_ the main repo. This seems like a very bad idea, and I can't imagine any possible benefit from doing that. Anyway, in this case, since the `cd githubActionsMetadataUpdates` line was missing, I was still in the `ld-find-code-refs` repo (where the 2.14.0 tag had already been created), and so the [error](https://github.com/launchdarkly/ld-find-code-refs/actions/runs/16786640560/job/47538679234#step:7:785) I got was `fatal: tag 'v2.14.0' already exists` 😬. This could have been very bad depending on what git operations I was doing. I'll make sure this gets fixed up in the very near term.

[^1]: I typically opt for `()`-style (instead of `{}`-style) functions in the shell because local variables behave how you would expect. This style of function creates a subshell, so any kind of file system navigation is not preserved. I had assumed since the `setup_gha` finishes in the `githubActionsMetadataUpdates` directory, that's where I would be when running the git commands. But since that function ran in a subshell, I was put back in the `ld-find-code-refs` root directory (the directory my GHA is run from).
<!-- ld-jira-link -->
---
Related Jira issue: [REL-4161: Migrate ld-find-code-refs from Releaser to GHA](https://launchdarkly.atlassian.net/browse/REL-4161)
<!-- end-ld-jira-link -->