### PR TITLE
dont run setup or cleanup if tag already exists

### DIFF
--- a/scripts/release/targets/bitbucket.sh
+++ b/scripts/release/targets/bitbucket.sh
@@ -22,18 +22,19 @@ clean_up_bitbucket() (
 )
 
 publish_bitbucket() (
-  setup_bitbucket
-
-  if git ls-remote --tags origin "refs/tags/v$LD_RELEASE_VERSION" | grep -q "v$LD_RELEASE_VERSION"; then
+  if git ls-remote --tags https://bitbucket.org/launchdarkly/ld-find-code-refs-pipe.git "refs/tags/v$LD_RELEASE_VERSION" | grep -q "v$LD_RELEASE_VERSION"; then
     echo "Version exists; skipping publishing BitBucket Pipe"
   else
-    cd bitbucketMetadataUpdates
+    setup_bitbucket
+
     echo "Live run: will publish pipe to bitbucket."
+
+    cd bitbucketMetadataUpdates
     git tag "$LD_RELEASE_VERSION"
     git push bb-origin master --tags
-  fi
 
-  clean_up_bitbucket
+    clean_up_bitbucket
+  fi
 )
 
 dry_run_bitbucket() (

--- a/scripts/release/targets/gha.sh
+++ b/scripts/release/targets/gha.sh
@@ -37,11 +37,11 @@ clean_up_gha() (
 )
 
 publish_gha() (
-  setup_gha
-
-  if git ls-remote --tags origin "refs/tags/v$LD_RELEASE_VERSION" | grep -q "v$LD_RELEASE_VERSION"; then
+  if git ls-remote --tags git@github.com:launchdarkly/find-code-references.git "refs/tags/v$LD_RELEASE_VERSION" | grep -q "v$LD_RELEASE_VERSION"; then
     echo "Version exists; skipping publishing GHA"
   else
+    setup_gha
+
     echo "Live run: will publish action to github action marketplace."
 
     cd githubActionsMetadataUpdates
@@ -51,9 +51,9 @@ publish_gha() (
     git tag -f "$RELEASE_TAG_MAJOR"
     git push -f origin "$RELEASE_TAG_MAJOR"
     gh release create "$RELEASE_TAG" --notes "$RELEASE_NOTES"
-  fi
 
-  clean_up_gha
+    clean_up_gha
+  fi
 )
 
 dry_run_gha() (


### PR DESCRIPTION
This update moves the setup and cleanup calls inside the block that runs only when the tag doesn't already exist. We were already ensure that the release didn't happen if the tag exists, but it turns out calling setup breaks if the tag already exists because we try to create an empty commit (because the changes already exist). Cursor also noticed that using the fully-qualified repo in the tag check is wiser since we have this weird nested git repo thing going on, and we don't want to check the wrong repo. I'll be updating this so the repos are fully isolated once I get this release out the door.