### PR TITLE
chore: fix up tag checks

### DIFF
--- a/scripts/release/push-to-origin.sh
+++ b/scripts/release/push-to-origin.sh
@@ -2,21 +2,20 @@
 
 set -euo pipefail
 
-release_tag="v${LD_RELEASE_VERSION}"
+release_tag="v$LD_RELEASE_VERSION"
 
 tag_exists() (
-  git fetch --tags
-  git rev-parse "${release_tag}" >/dev/null 2>&1
+  git ls-remote --tags git@github.com:launchdarkly/ld-find-code-refs.git "refs/tags/$release_tag" | grep -q "$release_tag"
 )
 
 push_to_origin() (
   if tag_exists; then
     echo "Tag $release_tag already exists. Aborting."
-    exit 1
+    return 0
   fi
 
   git push origin HEAD
-  git push origin "${release_tag}"
+  git push origin "$release_tag"
 )
 
 if [[ "$DRY_RUN" == "true" ]]; then

--- a/scripts/release/targets/bitbucket.sh
+++ b/scripts/release/targets/bitbucket.sh
@@ -21,23 +21,33 @@ clean_up_bitbucket() (
   cd .. && rm -rf bitbucketMetadataUpdates
 )
 
+tag_exists() (
+  git ls-remote --tags https://bitbucket.org/launchdarkly/ld-find-code-refs-pipe.git "refs/tags/v$LD_RELEASE_VERSION" | grep -q "v$LD_RELEASE_VERSION"
+)
+
 publish_bitbucket() (
-  if git ls-remote --tags https://bitbucket.org/launchdarkly/ld-find-code-refs-pipe.git "refs/tags/v$LD_RELEASE_VERSION" | grep -q "v$LD_RELEASE_VERSION"; then
+  if tag_exists; then
     echo "Version exists; skipping publishing BitBucket Pipe"
-  else
-    setup_bitbucket
-
-    echo "Live run: will publish pipe to bitbucket."
-
-    cd bitbucketMetadataUpdates
-    git tag "$LD_RELEASE_VERSION"
-    git push bb-origin master --tags
-
-    clean_up_bitbucket
+    return 0
   fi
+
+  setup_bitbucket
+
+  echo "Live run: will publish pipe to bitbucket."
+
+  cd bitbucketMetadataUpdates
+  git tag "$LD_RELEASE_VERSION"
+  git push bb-origin master --tags
+
+  clean_up_bitbucket
 )
 
 dry_run_bitbucket() (
+  if tag_exists; then
+    echo "Version exists; skipping push dry-run BitBucket Pipe"
+    return 0
+  fi
+
   setup_bitbucket
 
   echo "Dry run: will not publish pipe to bitbucket."


### PR DESCRIPTION
Two things being updated here:
1. update the tag-check (for this repo) to only check the remote repo for the tag. It will definitely exist in the local copy since we need to create it before running Goreleaser. Other minor tweak is that instead of bailing on the entire action, we just return 0, so the action can continue to run and complete the final step of creating the Github release. The only reason we're likely to be running the action again if the tag was created, is that the Github release failed, so we want to let the action continue, so it can do that last step.
2. checking for existing tag (GHA and Bitbucket Pipe) on dry-run as well. This was fixed for real runs of the action, but dry-runs will also bomb out if the tag exists (the tag could exist if we previously had a partially successful run, but need to re-run the action to retry the parts that didn't complete successfully)