### PR TITLE
chore: [REL-4161] make the circleci orb check more reliable

### DIFF
--- a/scripts/release/targets/circleci.sh
+++ b/scripts/release/targets/circleci.sh
@@ -60,7 +60,7 @@ publish_circleci() (
   install_circleci
   validate_circleci_orb_config
 
-  if circleci orb list | grep launchdarkly/ld-find-code-refs@$LD_RELEASE_VERSION; then
+  if circleci orb info "launchdarkly/ld-find-code-refs@$LD_RELEASE_VERSION" >/dev/null 2>&1; then
     echo "Version exists; skipping publishing CircleCI Orb"
   else
     echo "Live run: will publish orb to production circleci repo."


### PR DESCRIPTION
Orb check caused the action to [fail](https://github.com/launchdarkly/ld-find-code-refs/actions/runs/16807638943/job/47604213552#step:7:679) last time. The way we were doing the check was not great as it pulls every single public Orb and greps for the coderefs orb with the version we're looking for. I tried that locally and verified that it doesn't find the orb (even though it exists). I also tried the updated orb check locally, which is way more efficient and does find the Orb we're looking for.
<!-- ld-jira-link -->
---
Related Jira issue: [REL-4161: Migrate ld-find-code-refs from Releaser to GHA](https://launchdarkly.atlassian.net/browse/REL-4161)
<!-- end-ld-jira-link -->