### PR TITLE
chore: [REL-4161] use elevated token for git stuff

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,6 @@ jobs:
       LD_RELEASE_VERSION: ${{ inputs.releaseVersion }}
       DRY_RUN: ${{ inputs.dryRun || 'false' }}
       CHANGELOG_ENTRY: ${{ inputs.changeLog }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       HOMEBREW_GH_TOKEN: ${{ secrets.LAUNCHDARKLY_HOMEBREW_TAP_DEPLOY_KEY }}
       ARTIFACT_DIRECTORY: "/tmp/release-artifacts"
     steps:
@@ -37,7 +36,9 @@ jobs:
         uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.2.0
         with:
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
-          ssm_parameter_pairs: '/global/services/docker/public/username = DOCKER_USERNAME, /global/services/docker/public/token = DOCKER_TOKEN, /production/common/releasing/circleci/orb-token= CIRCLECI_CLI_TOKEN, /production/common/releasing/bitbucket/username = BITBUCKET_USERNAME, /production/common/releasing/bitbucket/token = BITBUCKET_TOKEN'
+          ssm_parameter_pairs: '/global/services/docker/public/username = DOCKER_USERNAME, /global/services/docker/public/token = DOCKER_TOKEN, /production/common/releasing/circleci/orb-token= CIRCLECI_CLI_TOKEN, /production/common/releasing/bitbucket/username = BITBUCKET_USERNAME, /production/common/releasing/bitbucket/token = BITBUCKET_TOKEN, /production/common/releasing/ld-find-code-refs/github-release-token = GITHUB_RELEASE_TOKEN'
+      - name: set release token
+        run: echo "GITHUB_TOKEN=$GITHUB_RELEASE_TOKEN" >> $GITHUB_ENV
       - name: setup access for find-code-references
         uses: launchdarkly/gh-actions/actions/ssh-key-by-repo@main
         with:
@@ -72,7 +73,6 @@ jobs:
         uses: ncipollo/release-action@v1.14.0
         if: ${{ !inputs.dryRun }}
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           tag: v${{ inputs.releaseVersion }}
           body: ${{ inputs.changeLog }}
           artifacts: ${{ env.ARTIFACT_DIRECTORY }}/*


### PR DESCRIPTION
The GITHUB_TOKEN that's built-in to the GHA is not authorized to push directly to main. We need to do this in order to push up our committed changes to the remote repo so we can create the release. I had a new SSM parameter added that will allow this, so we should be able to cut the release now with this new token. I needed to get a little creative since the value is not known until after the `get secrets` step runs, but I think what I have here should work.
<!-- ld-jira-link -->
---
Related Jira issue: [REL-4161: Migrate ld-find-code-refs from Releaser to GHA](https://launchdarkly.atlassian.net/browse/REL-4161)
<!-- end-ld-jira-link -->