### PR TITLE
feat: add debug logging for HTTP response status codes

### DIFF
--- a/internal/ld/ld.go
+++ b/internal/ld/ld.go
@@ -485,6 +485,8 @@ func (c ApiClient) do(req *h.Request) (*http.Response, error) {
 		return nil, err
 	}
 
+	log.Debug.Printf("response status %d %s for %s %s", res.StatusCode, http.StatusText(res.StatusCode), req.Method, req.URL)
+
 	// Check for all general status codes returned by the code references API, attempting to deconstruct LD error messages, if possible.
 	switch res.StatusCode {
 	case http.StatusOK, http.StatusCreated, http.StatusNoContent:


### PR DESCRIPTION
## Summary

Adds debug logging for HTTP response status codes in the API client's `do` method. When running with `--debug` enabled, all API responses will now log their status code, status text, HTTP method, and URL.

This addresses an issue where 413 (Request Entity Too Large) errors appeared as silent failures - the tool would report sending code references successfully, but nothing would appear in LaunchDarkly because the payload was rejected.

Example debug output:
```
DEBUG: 2026/01/14 12:00:00 ld.go:488: response status 413 Request Entity Too Large for PUT https://app.launchdarkly.com/api/v2/code-refs/repositories/...
```
