### PR TITLE
chore: Update prepare-release.sh

### DIFF
--- a/scripts/release/prepare-release.sh
+++ b/scripts/release/prepare-release.sh
@@ -8,10 +8,10 @@ update_go() (
   sed -i "s/const Version =.*/const Version = \"${LD_RELEASE_VERSION}\"/g" internal/version/version.go
 )
 
-update_orb() (
-  sed -i "s#launchdarkly/ld-find-code-refs@.*#launchdarkly/ld-find-code-refs@${LD_RELEASE_VERSION}#g" build/package/circleci/orb.yml
-  sed -i "s#- image: launchdarkly/ld-find-code-refs:.*#- image: launchdarkly/ld-find-code-refs:${LD_RELEASE_VERSION}#g" build/package/circleci/orb.yml
-)
+# update_orb() (
+#   sed -i "s#launchdarkly/ld-find-code-refs@.*#launchdarkly/ld-find-code-refs@${LD_RELEASE_VERSION}#g" build/package/circleci/orb.yml
+#   sed -i "s#- image: launchdarkly/ld-find-code-refs:.*#- image: launchdarkly/ld-find-code-refs:${LD_RELEASE_VERSION}#g" build/package/circleci/orb.yml
+# )
 
 update_gha() (
   sed -i "s#launchdarkly/find-code-references@v.*#launchdarkly/find-code-references@${release_tag}#g" build/metadata/github-actions/README.md
@@ -39,7 +39,7 @@ update_changelog() (
 
 # update metadata files and CHANGELOG
 update_go
-update_orb
+# update_orb
 update_gha
 update_bitbucket
 update_changelog

--- a/scripts/release/publish-dry-run.sh
+++ b/scripts/release/publish-dry-run.sh
@@ -21,4 +21,4 @@ done
 
 dry_run_bitbucket
 dry_run_gha
-dry_run_circleci
+# dry_run_circleci

--- a/scripts/release/publish.sh
+++ b/scripts/release/publish.sh
@@ -18,5 +18,5 @@ for script in $(dirname $0)/targets/*.sh; do
 done
 
 publish_gha
-publish_circleci
+# publish_circleci
 publish_bitbucket


### PR DESCRIPTION
This pull request comments out (disables) all logic related to updating and publishing the CircleCI orb as part of the release process. The changes ensure that the release scripts no longer update or publish the CircleCI orb, but the code is left in place as comments for potential future use.

Reason: Working on getting right policies in place for releasing latest circle ci orbs.


Release script changes:

* Commented out the `update_orb` function and its invocation in `scripts/release/prepare-release.sh`, so the CircleCI orb is no longer updated during release preparation. [[1]](diffhunk://#diff-8f9353b073959e418dcad74c8f81d67c89314e3ead7a8bca078cc5d3d9f54747L11-R14) [[2]](diffhunk://#diff-8f9353b073959e418dcad74c8f81d67c89314e3ead7a8bca078cc5d3d9f54747L42-R42)
* Commented out the `dry_run_circleci` step in `scripts/release/publish-dry-run.sh`, removing the CircleCI orb dry run from the release dry run process.
* Commented out the `publish_circleci` step in `scripts/release/publish.sh`, so the CircleCI orb is no longer published during the release.