### PR TITLE
chore: disabling gha, bitbucket publishing, unblocking docker hub release

### DIFF
--- a/scripts/release/prepare-release.sh
+++ b/scripts/release/prepare-release.sh
@@ -13,15 +13,15 @@ update_go() (
 #   sed -i "s#- image: launchdarkly/ld-find-code-refs:.*#- image: launchdarkly/ld-find-code-refs:${LD_RELEASE_VERSION}#g" build/package/circleci/orb.yml
 # )
 
-update_gha() (
-  sed -i "s#launchdarkly/find-code-references@v.*#launchdarkly/find-code-references@${release_tag}#g" build/metadata/github-actions/README.md
-  sed -i "s#launchdarkly/ld-find-code-refs-github-action:.*#launchdarkly/ld-find-code-refs-github-action:${LD_RELEASE_VERSION}#g" build/metadata/github-actions/Dockerfile
-)
+# update_gha() (
+#   sed -i "s#launchdarkly/find-code-references@v.*#launchdarkly/find-code-references@${release_tag}#g" build/metadata/github-actions/README.md
+#   sed -i "s#launchdarkly/ld-find-code-refs-github-action:.*#launchdarkly/ld-find-code-refs-github-action:${LD_RELEASE_VERSION}#g" build/metadata/github-actions/Dockerfile
+# )
 
-update_bitbucket() (
-  sed -i "s#- pipe: launchdarkly/ld-find-code-refs-pipe.*#- pipe: launchdarkly/ld-find-code-refs-pipe:${LD_RELEASE_VERSION}#g" build/metadata/bitbucket/README.md
-  sed -i "s#image: launchdarkly/ld-find-code-refs-bitbucket-pipeline:.*#image: launchdarkly/ld-find-code-refs-bitbucket-pipeline:${LD_RELEASE_VERSION}#g" build/metadata/bitbucket/pipe.yml
-)
+# update_bitbucket() (
+#   sed -i "s#- pipe: launchdarkly/ld-find-code-refs-pipe.*#- pipe: launchdarkly/ld-find-code-refs-pipe:${LD_RELEASE_VERSION}#g" build/metadata/bitbucket/README.md
+#   sed -i "s#image: launchdarkly/ld-find-code-refs-bitbucket-pipeline:.*#image: launchdarkly/ld-find-code-refs-bitbucket-pipeline:${LD_RELEASE_VERSION}#g" build/metadata/bitbucket/pipe.yml
+# )
 
 update_changelog() (
   local ts=$(date +"%Y-%m-%d")
@@ -40,8 +40,8 @@ update_changelog() (
 # update metadata files and CHANGELOG
 update_go
 # update_orb
-update_gha
-update_bitbucket
+# update_gha
+# update_bitbucket
 update_changelog
 
 # commit changes and create tag

--- a/scripts/release/publish-dry-run.sh
+++ b/scripts/release/publish-dry-run.sh
@@ -12,13 +12,13 @@ BASE_CODEREFS=ld-find-code-refs
 GH_CODEREFS=ld-find-code-refs-github-action
 BB_CODEREFS=ld-find-code-refs-bitbucket-pipeline
 sudo docker save launchdarkly/${BASE_CODEREFS}:latest | gzip >${ARTIFACT_DIRECTORY}/${BASE_CODEREFS}.tar.gz
-sudo docker save launchdarkly/${GH_CODEREFS}:latest | gzip >${ARTIFACT_DIRECTORY}/${GH_CODEREFS}.tar.gz
-sudo docker save launchdarkly/${BB_CODEREFS}:latest | gzip >${ARTIFACT_DIRECTORY}/${BB_CODEREFS}.tar.gz
+# sudo docker save launchdarkly/${GH_CODEREFS}:latest | gzip >${ARTIFACT_DIRECTORY}/${GH_CODEREFS}.tar.gz
+# sudo docker save launchdarkly/${BB_CODEREFS}:latest | gzip >${ARTIFACT_DIRECTORY}/${BB_CODEREFS}.tar.gz
 
 for script in $(dirname $0)/targets/*.sh; do
   source $script
 done
 
-dry_run_bitbucket
-dry_run_gha
+# dry_run_bitbucket
+# dry_run_gha
 # dry_run_circleci

--- a/scripts/release/publish.sh
+++ b/scripts/release/publish.sh
@@ -17,6 +17,6 @@ for script in $(dirname $0)/targets/*.sh; do
   source $script
 done
 
-publish_gha
+# publish_gha
 # publish_circleci
-publish_bitbucket
+# publish_bitbucket


### PR DESCRIPTION
This PR disables GitHub Actions and Bitbucket publishing while unblocking Docker Hub releases.

Changes:
- Updated prepare-release.sh to skip GHA and Bitbucket targets
- Updated publish-dry-run.sh to skip GHA and Bitbucket targets
- Updated publish.sh to skip GHA and Bitbucket targets