### PR TITLE
chore: temp remove unneeded code

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.2.0
         with:
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
-          ssm_parameter_pairs: '/global/services/docker/public/username = DOCKER_USERNAME, /global/services/docker/public/token = DOCKER_TOKEN, /production/common/releasing/circleci/orb-token= CIRCLECI_CLI_TOKEN, /production/common/releasing/bitbucket/username = BITBUCKET_USERNAME, /production/common/releasing/bitbucket/token = BITBUCKET_TOKEN, /production/common/releasing/ld-find-code-refs/github-release-token = GITHUB_RELEASE_TOKEN'
+          ssm_parameter_pairs: '/global/services/docker/public/username = DOCKER_USERNAME, /global/services/docker/public/token = DOCKER_TOKEN
       - name: set release token
         run: echo "GITHUB_TOKEN=$GITHUB_RELEASE_TOKEN" >> $GITHUB_ENV
       - name: setup access for find-code-references


### PR DESCRIPTION
This PR removes unused SSM parameters from the release workflow to streamline secret retrieval.

## Changes
- Removed the following token references from `ssm_parameter_pairs` that are no longer needed:
  - CIRCLECI_CLI_TOKEN
  - BITBUCKET_USERNAME
  - BITBUCKET_TOKEN
  - GITHUB_RELEASE_TOKEN (via SSM)

## Why
targeting a release to dockerhub only