### PR TITLE
Update CODEOWNERS: rename team-fm-next to team-fm-foundations

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,12 +1,12 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-* @launchdarkly/team-fm-next
+* @launchdarkly/team-fm-foundations
 
 # Documentation
 *.md @launchdarkly/team-docs
 
 # vendor docs don't need to be owned by docs team
-vendor/ @launchdarkly/team-fm-next
+vendor/ @launchdarkly/team-fm-foundations
 
 # Change log is updated by release bot
-CHANGELOG.md @launchdarkly/team-fm-next
+CHANGELOG.md @launchdarkly/team-fm-foundations


### PR DESCRIPTION
## Summary

Replaces all references to `@launchdarkly/team-fm-next` with `@launchdarkly/team-fm-foundations` in the CODEOWNERS file to reflect the team rename.

This is one of several PRs making this change across the `launchdarkly` org.

## Review & Testing Checklist for Human

- [ ] Verify that `@launchdarkly/team-fm-foundations` is a valid, active team in the GitHub org (CODEOWNERS silently fails if the team doesn't exist)
- [ ] Confirm no other references to `team-fm-next` remain in this repo outside of CODEOWNERS

### Notes

Three ownership rules were updated: the default (`*`), `vendor/`, and `CHANGELOG.md`.

Link to Devin session: https://app.devin.ai/sessions/8abe80d07e414755864c1b9c67215686
Requested by: @kparkinson-ld