### PR TITLE
chore: prepare release 2.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the ld-find-code-refs program will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [2.16.0] - 2026-07-28
+Version 2.15.0 was never released. Its Docker images exist on Docker Hub from an incomplete release run, but there is no 2.15.0 tag, release, or changelog entry. Use 2.16.0 instead.
+
+### Added:
+- debug logging for HTTP response status codes
+- auth header for GitHub Action runs
+
+### Fixed:
+- filepattern alias contents are now concatenated once per alias rather than once per flag key, fixing out-of-memory failures on large repositories
+
+### Changed:
+- updated dependencies
+
 ## [2.14.0] - 2025-08-12
 ### Added:
 - `--skipArchivedFlags` option to instruct the tool to ignore any flag keys it finds from archived flags

--- a/build/metadata/github-actions/Dockerfile
+++ b/build/metadata/github-actions/Dockerfile
@@ -1,4 +1,4 @@
-FROM launchdarkly/ld-find-code-refs-github-action:2.14.0
+FROM launchdarkly/ld-find-code-refs-github-action:2.16.0
 
 LABEL com.github.actions.name="LaunchDarkly Code References"
 LABEL com.github.actions.description="Find references to feature flags in your code."

--- a/build/metadata/github-actions/README.md
+++ b/build/metadata/github-actions/README.md
@@ -28,7 +28,7 @@ jobs:
       with:
         fetch-depth: 11 # This value must be set if the lookback configuration option is not disabled for find-code-references. Read more: https://github.com/launchdarkly/ld-find-code-refs#searching-for-unused-flags-extinctions
     - name: LaunchDarkly Code References
-      uses: launchdarkly/find-code-references@v2.14.0
+      uses: launchdarkly/find-code-references@v2.16.0
       with:
         accessToken: ${{ secrets.LD_ACCESS_TOKEN }}
         projKey: LD_PROJECT_KEY
@@ -71,7 +71,7 @@ jobs:
       with:
         fetch-depth: 11 # This value must be set if the lookback configuration option is not disabled for find-code-references. Read more: https://github.com/launchdarkly/ld-find-code-refs#searching-for-unused-flags-extinctions
     - name: LaunchDarkly Code References
-      uses: launchdarkly/find-code-references@v2.14.0
+      uses: launchdarkly/find-code-references@v2.16.0
       with:
         accessToken: ${{ secrets.LD_ACCESS_TOKEN }}
         projKey: LD_PROJECT_KEY

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "2.14.0"
+const Version = "2.16.0"


### PR DESCRIPTION
## Summary

Prepares the 2.16.0 release by hand. This is the same approach taken for 2.14.0 in #563: the release workflow can publish artifacts but cannot complete a release, so the version bump lands as a normal PR and the tag, GitHub release, and downstream action update are done manually afterward.

Related to #607 — the fix being asked for there is #604. That issue stays open until the release and the downstream action update are actually out.

## Why by hand

`scripts/release/prepare-release.sh` commits the version bump and changelog entry, then `push-to-origin.sh` pushes that commit straight to `main`. Rulesets reject it:

```
remote: error: GH013: Repository rule violations found for refs/heads/main
remote: - Changes must be made through a pull request.
 ! [remote rejected] HEAD -> main
```

This has now failed the same way three times: August 2025 (worked around manually in #563), January 2026 (#593–#595, which disabled the GHA/Bitbucket/CircleCI publish targets to get a Docker-only release out), and again today. The plan stated in #563 was to move to Release Please so that releasing never pushes to `main`. That hasn't happened yet, so this PR follows the manual path again.

## What changed

| File | Change |
| --- | --- |
| `internal/version/version.go` | `2.14.0` → `2.16.0` |
| `CHANGELOG.md` | 2.16.0 entry, plus a note that 2.15.0 was never released |
| `build/metadata/github-actions/Dockerfile` | image tag → `2.16.0` |
| `build/metadata/github-actions/README.md` | `find-code-references@v2.16.0` |

## Behavior notes

- **Numbering skips 2.15.0.** January's run pushed `ld-find-code-refs:2.15.0` and `ld-find-code-refs-github-action:2.15.0` to Docker Hub before failing, so those tags are already taken. Releasing as 2.16.0 keeps published images immutable.
- **Docker images for 2.16.0 are already published.** Today's run got as far as `publish` before failing, so `2.16.0` and `latest` are on Docker Hub, built from `d2b674b` with the version constant patched to 2.16.0.
- **`brew install ld-find-code-refs` is broken right now.** That same run updated the homebrew tap formula to 2.16.0, but its download URLs point at release assets that don't exist yet. Creating the GitHub release fixes it; the shas need regenerating because the assets will come from a local build rather than the CI build.
- **Bitbucket and CircleCI metadata deliberately untouched.** Those targets stopped being published in January, so bumping them would name a pipe version and orb version that were never cut.

## Testing

`go build ./...` and `go test ./aliases/...` pass. Nothing here is executable code beyond the version constant.

## Provenance

Rebuilt as two narrative commits on `release-2.16.0-clean`; the original branch is [`release-2.16.0`](https://github.com/launchdarkly/ld-find-code-refs/tree/release-2.16.0). Tree hashes verified identical.
