### PR TITLE
feat: optional GitHub Action dockerImage entry point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the ld-find-code-refs program will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [Unreleased]
+
+### Added:
+- optional GitHub Action entry point `launchdarkly/find-code-references/docker` with a `dockerImage` input so workflows can pull the scanner image from a private registry or Docker Hub proxy. The root Action is unchanged.
+
 ## [2.16.0] - 2026-07-28
 Version 2.15.0 was never released. Its Docker images exist on Docker Hub from an incomplete release run, but there is no 2.15.0 tag, release, or changelog entry. Use 2.16.0 instead.
 

--- a/build/metadata/github-actions/README.md
+++ b/build/metadata/github-actions/README.md
@@ -40,6 +40,39 @@ Commit this file under a new branch. Submit as a PR to your code reviewers to be
 
 As shown in the above example, the workflow should run on the `push` event, and contain an action provided by the [launchdarkly/find-code-references repository](https://github.com/launchdarkly/find-code-references). The `LD_ACCESS_TOKEN` configured in the previous step should be included as a secret, as well as a new environment variable containing your LaunchDarkly project key.
 
+## Using a private or mirrored container registry
+
+The root Action (`launchdarkly/find-code-references@v2`) is a Docker container action. GitHub always pulls its image from the registry hardcoded in that Action's Dockerfile (Docker Hub), and that image reference cannot be overridden with an input.
+
+If your organization must pull images through an internal registry or Docker Hub proxy, use the optional **`docker`** entry point in the same Action repository. It accepts a `dockerImage` input and runs the scanner with `docker run` after you authenticate to your registry.
+
+```yaml
+on: push
+name: Find LaunchDarkly flag code references
+jobs:
+  launchDarklyCodeReferences:
+    name: LaunchDarkly Code References
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 11
+    - uses: docker/login-action@v3
+      with:
+        registry: your.registry.example
+        username: ${{ secrets.REGISTRY_USER }}
+        password: ${{ secrets.REGISTRY_TOKEN }}
+    - name: LaunchDarkly Code References
+      # Pin to a release that includes the docker/ entry point (see changelog).
+      uses: launchdarkly/find-code-references/docker@v2.17.0
+      with:
+        accessToken: ${{ secrets.LD_ACCESS_TOKEN }}
+        projKey: LD_PROJECT_KEY
+        dockerImage: your.registry.example/launchdarkly/ld-find-code-refs-github-action:2.16.0
+```
+
+Mirror the public image `launchdarkly/ld-find-code-refs-github-action` into your registry (pin `dockerImage` to the scanner image tag you mirrored; it can lag the Action tag). This entry point requires a Docker CLI on the runner (included on GitHub-hosted `ubuntu-*` runners). Existing workflows that use the root Action do not need to change.
+
 ## Additional configuration
 
 To customize additional configuration not referenced in [Inputs](#inputs), you may use a configuration file located at `.launchdarkly/coderefs.yml`. The following links provide more inforation about configurable options:

--- a/build/metadata/github-actions/docker/action.yml
+++ b/build/metadata/github-actions/docker/action.yml
@@ -1,7 +1,7 @@
 name: LaunchDarkly Code References (custom image)
 description: >-
   Find references to feature flags in your code. Same scanner as the root
-  Action, but runs via docker run so you can override the image registry
+  Action, but runs using docker run so you can override the image registry
   (for example an internal Docker Hub proxy).
 author: LaunchDarkly
 branding:

--- a/build/metadata/github-actions/docker/action.yml
+++ b/build/metadata/github-actions/docker/action.yml
@@ -1,0 +1,121 @@
+name: LaunchDarkly Code References (custom image)
+description: >-
+  Find references to feature flags in your code. Same scanner as the root
+  Action, but runs via docker run so you can override the image registry
+  (for example an internal Docker Hub proxy).
+author: LaunchDarkly
+branding:
+  icon: toggle-right
+  color: gray-dark
+inputs:
+  accessToken:
+    description: "A token with write access to the LaunchDarkly project."
+    required: true
+  allowTags:
+    default: "false"
+    description: "Enable storing references for tags. Lists the tag as a branch."
+    required: false
+  baseUri:
+    default: "https://app.launchdarkly.com"
+    description: "The base URL of the LaunchDarkly server for this configuration."
+    required: false
+  contextLines:
+    default: "2"
+    description: "The number of context lines above and below a code reference for the job to send to LaunchDarkly. By default, the flag finder will not send any context lines to LaunchDarkly. If < 0, it will send no source code to LaunchDarkly. If 0, it will send only the lines containing flag references. If > 0, it will send that number of context lines above and below the flag reference. You may provide a maximum of 5 context lines."
+    required: false
+  debug:
+    default: "false"
+    description: "Enable verbose debug logging."
+    required: false
+  ignoreServiceErrors:
+    default: "false"
+    description: "If enabled, the scanner will terminate with exit code 0 when the LaunchDarkly API is unreachable or returns an unexpected response."
+    required: false
+  lookback:
+    default: "10"
+    description: "Set the number of commits to search in history for whether you removed a feature flag from code. You may set to 0 to disable this feature. Setting this option to a high value will increase search time."
+    required: false
+  projKey:
+    description: "Key of the LaunchDarkly project associated with this repository. Found under Account Settings -> Projects in the LaunchDarkly dashboard. Cannot be combined with `projects` block in configuration file."
+    required: false
+  repoName:
+    description: "The repository name. Defaults to the current GitHub repository."
+    required: false
+  prune:
+    default: "false"
+    description: "There is a known issue where the GitHub Action will not prune deleted branch data in private repos. Only enable this if you are running the action in a public repo."
+    required: false
+  subdirectory:
+    description: "The subdirectory to run the action in."
+    required: false
+  dockerImage:
+    description: >-
+      Container image to run. Defaults to the public Docker Hub image used by
+      the root Action. Set this to your mirrored/proxy image (for example
+      your.registry.example/launchdarkly/ld-find-code-refs-github-action:2.16.0).
+      Authenticate to private registries with docker/login-action (or equivalent)
+      in a prior step. Requires a runner with a Docker CLI (GitHub-hosted
+      ubuntu-* runners include one).
+    required: false
+    default: "launchdarkly/ld-find-code-refs-github-action:2.16.0"
+runs:
+  using: composite
+  steps:
+    - name: Run LaunchDarkly Code References
+      shell: bash
+      env:
+        DOCKER_IMAGE: ${{ inputs.dockerImage }}
+        LD_PROJ_KEY: ${{ inputs.projKey }}
+        LD_ACCESS_TOKEN: ${{ inputs.accessToken }}
+        LD_REPO_NAME: ${{ inputs.repoName }}
+        LD_BASE_URI: ${{ inputs.baseUri }}
+        LD_CONTEXT_LINES: ${{ inputs.contextLines }}
+        LD_ALLOW_TAGS: ${{ inputs.allowTags }}
+        LD_DEBUG: ${{ inputs.debug }}
+        LD_IGNORE_SERVICE_ERRORS: ${{ inputs.ignoreServiceErrors }}
+        LD_LOOKBACK: ${{ inputs.lookback }}
+        LD_PRUNE: ${{ inputs.prune }}
+        LD_SUBDIRECTORY: ${{ inputs.subdirectory }}
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+
+        if [[ -z "${DOCKER_IMAGE:-}" ]]; then
+          echo "::error::dockerImage input must not be empty"
+          exit 1
+        fi
+        if [[ -z "${GITHUB_WORKSPACE:-}" || ! -d "${GITHUB_WORKSPACE}" ]]; then
+          echo "::error::GITHUB_WORKSPACE is missing or not a directory; ensure actions/checkout ran before this step"
+          exit 1
+        fi
+        if [[ -z "${GITHUB_EVENT_PATH:-}" || ! -f "${GITHUB_EVENT_PATH}" ]]; then
+          echo "::error::GITHUB_EVENT_PATH is missing or not a readable file"
+          exit 1
+        fi
+        if ! command -v docker >/dev/null 2>&1; then
+          echo "::error::docker CLI not found on the runner; this Action entry point requires Docker"
+          exit 1
+        fi
+
+        docker run --rm \
+          -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" \
+          -w "${GITHUB_WORKSPACE}" \
+          -v "${GITHUB_EVENT_PATH}:${GITHUB_EVENT_PATH}:ro" \
+          -e GITHUB_WORKSPACE \
+          -e GITHUB_EVENT_PATH \
+          -e GITHUB_REPOSITORY \
+          -e GITHUB_REF \
+          -e GITHUB_ACTIONS=true \
+          -e GITHUB_TOKEN \
+          -e LD_PROJ_KEY \
+          -e LD_ACCESS_TOKEN \
+          -e LD_REPO_NAME \
+          -e LD_BASE_URI \
+          -e LD_CONTEXT_LINES \
+          -e LD_ALLOW_TAGS \
+          -e LD_DEBUG \
+          -e LD_IGNORE_SERVICE_ERRORS \
+          -e LD_LOOKBACK \
+          -e LD_PRUNE \
+          -e LD_SUBDIRECTORY \
+          "${DOCKER_IMAGE}"

--- a/build/metadata/github-actions/docker/action.yml
+++ b/build/metadata/github-actions/docker/action.yml
@@ -97,6 +97,13 @@ runs:
           exit 1
         fi
 
+        proxy_env=()
+        for v in HTTP_PROXY HTTPS_PROXY NO_PROXY http_proxy https_proxy no_proxy; do
+          if [[ -n "${!v:-}" ]]; then
+            proxy_env+=(-e "$v")
+          fi
+        done
+
         docker run --rm \
           -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" \
           -w "${GITHUB_WORKSPACE}" \
@@ -118,4 +125,5 @@ runs:
           -e LD_LOOKBACK \
           -e LD_PRUNE \
           -e LD_SUBDIRECTORY \
+          "${proxy_env[@]}" \
           "${DOCKER_IMAGE}"

--- a/build/metadata/github-actions/docker/action.yml
+++ b/build/metadata/github-actions/docker/action.yml
@@ -36,7 +36,7 @@ inputs:
     description: "Set the number of commits to search in history for whether you removed a feature flag from code. You may set to 0 to disable this feature. Setting this option to a high value will increase search time."
     required: false
   projKey:
-    description: "Key of the LaunchDarkly project associated with this repository. Found under Account Settings -> Projects in the LaunchDarkly dashboard. Cannot be combined with `projects` block in configuration file."
+    description: "Key of the LaunchDarkly project associated with this repository. Found under Account Settings -> Projects in LaunchDarkly. Cannot be combined with `projects` block in configuration file."
     required: false
   repoName:
     description: "The repository name. Defaults to the current GitHub repository."

--- a/scripts/release/targets/gha.sh
+++ b/scripts/release/targets/gha.sh
@@ -28,7 +28,8 @@ setup_gha() (
   git config user.email "launchdarklyreleasebot@launchdarkly.com"
   git config user.name "LaunchDarklyReleaseBot"
   git branch -vv
-  git add -u
+  # -A stages new files (e.g. docker/action.yml) as well as updates to tracked files
+  git add -A
   git commit -m "Release auto update version $LD_RELEASE_VERSION"
   pwd
 )

--- a/scripts/release/targets/gha.sh
+++ b/scripts/release/targets/gha.sh
@@ -22,7 +22,8 @@ setup_gha() (
   # clone checkout commit and push all metadata changes to gha repo
   mkdir -p githubActionsMetadataUpdates
   gh repo clone launchdarkly/find-code-references githubActionsMetadataUpdates
-  cp build/metadata/github-actions/* githubActionsMetadataUpdates
+  # -a preserves the docker/ subdirectory entry point (and other nested metadata)
+  cp -a build/metadata/github-actions/. githubActionsMetadataUpdates/
   cd githubActionsMetadataUpdates
   git config user.email "launchdarklyreleasebot@launchdarkly.com"
   git config user.name "LaunchDarklyReleaseBot"


### PR DESCRIPTION
## Summary
- Adds an opt-in Action entry point at `launchdarkly/find-code-references/docker` with a `dockerImage` input so workflows can pull the scanner from a private registry or Docker Hub proxy.
- Leaves the root Docker container Action (`action.yml` + `Dockerfile`) **unchanged** so existing `uses: launchdarkly/find-code-references@v2` workflows keep the current GitHub-managed runtime.
- Fail-fast checks for `GITHUB_WORKSPACE`, `GITHUB_EVENT_PATH`, and `docker` CLI; release copy script now preserves nested metadata (`docker/`).

## Why not change the root Action
GitHub does not allow dynamic `runs.image` / `${{ inputs.* }}` on `using: docker` Actions ([docs](https://docs.github.com/en/actions/reference/workflows-and-actions/metadata-syntax#runsimage), [SO](https://stackoverflow.com/questions/58476228/how-to-use-a-variable-docker-image-in-github-actions)).

## Usage (after publish to find-code-references)
```yaml
- uses: docker/login-action@v3
  with:
    registry: your.registry.example
    username: ${{ secrets.REGISTRY_USER }}
    password: ${{ secrets.REGISTRY_TOKEN }}
- uses: launchdarkly/find-code-references/docker@v2.17.0
  with:
    accessToken: ${{ secrets.LD_ACCESS_TOKEN }}
    projKey: LD_PROJECT_KEY
    dockerImage: your.registry.example/launchdarkly/ld-find-code-refs-github-action:2.16.0
```

## Test plan

Composite + `docker run` can fail **quietly** (green CI, wrong/empty data in LD) if mounts or env are wrong. Test on a **real GitHub-hosted runner** (not only `act`), against a repo that already has known flag refs in LD.

### 0. Hygiene
- [ ] `git diff main -- build/metadata/github-actions/action.yml Dockerfile` is empty (root Action unchanged)
- [ ] Manual dry-run of release copy: `cp -a build/metadata/github-actions/. /tmp/fcr-test/` includes `docker/action.yml`

### 1. Baseline parity (default Hub image)
Workflow A — `/docker` with **no** `dockerImage` (uses default Hub tag):

```yaml
- uses: actions/checkout@v4
  with:
    fetch-depth: 11
- uses: ./build/metadata/github-actions/docker   # or published .../docker@branch
  with:
    accessToken: ${{ secrets.LD_ACCESS_TOKEN }}
    projKey: <known project>
    debug: true
```

Workflow B — same job, root Action (control):

```yaml
- uses: ./build/metadata/github-actions   # or launchdarkly/find-code-references@v2.16.0
  with:
    accessToken: ${{ secrets.LD_ACCESS_TOKEN }}
    projKey: <known project>
    debug: true
```

Assert:
- [x] Both jobs exit 0
- [x] Logs show the **same branch name** (not empty / not wrong PR head)
- [x] Hunk / flag counts are in the same ballpark (debug table or LD UI for that branch)
- [x] `GITHUB_EVENT_PATH` / workspace fail-fasts do **not** fire

**Failure modes this catches:** missing workspace mount (empty scan), missing event/ref (wrong branch).

### 2. Explicit Hub URI
- [x] Set `dockerImage: launchdarkly/ld-find-code-refs-github-action:2.16.0` explicitly — same results as §1

### 3. Mirrored registry
- [ ] Mirror/retag that image into a registry we control (GHCR or internal)
- [ ] `docker/login-action` then `/docker` with `dockerImage: <mirror URI>`
- [ ] Job pulls from the mirror (check logs for registry host) and produces same branch + similar ref counts as §1

**Failure modes this catches:** login ordering, wrong image tag, private pull auth.

### 4. Lookback / extinctions (git history in the container)
- [ ] `fetch-depth: 11`, `lookback: 10` (defaults)
- [ ] Logs show extinction lookback running without “unable to generate flag extinctions” / git errors caused by missing `.git`
- [ ] Prefer a branch where a flag was recently removed so an extinction can appear (or at least the lookback path executes cleanly)

**Failure modes this catches:** workspace mount without `.git`, shallow-clone mismatch.

### 5. Defaults parity vs CLI footguns
- [ ] Omit `prune` input — confirm behavior matches root Action (`prune` false), **not** CLI default true (check logs: should not attempt remote prune on a private repo unless enabled)
- [ ] Omit optional inputs — `lookback`/`contextLines` behave like root defaults

### 6. Negative / fail-loud checks (should be red, not silent)
- [ ] Temporarily break workspace (e.g. skip checkout) — step fails with `GITHUB_WORKSPACE` error
- [ ] Empty `dockerImage: ""` — step fails with empty-image error
- [ ] (Optional) Self-hosted without Docker — fails with docker CLI missing

### 7. Exit codes
- [ ] Invalid `accessToken` / unreachable API with `ignoreServiceErrors: false` — non-zero exit (not swallowed by the composite wrapper)
- [ ] `ignoreServiceErrors: true` — still respects scanner behavior (exit 0 on service errors)

### 8. Release follow-up
- [ ] Publish `docker/` into `launchdarkly/find-code-references`, tag (e.g. `v2.17.0`)
- [ ] Re-run §1–§3 against the **published** `uses: launchdarkly/find-code-references/docker@...` (not local path)


Made with [Cursor](https://cursor.com)