### PR TITLE
chore: prepare release 2.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the ld-find-code-refs program will be documented in this 
 
 ## [Unreleased]
 
+## [2.17.0] - 2026-08-13
+
 ### Added:
 - optional GitHub Action entry point `launchdarkly/find-code-references/docker` with a `dockerImage` input so workflows can pull the scanner image from a private registry or Docker Hub proxy. The root Action is unchanged.
 

--- a/build/metadata/github-actions/Dockerfile
+++ b/build/metadata/github-actions/Dockerfile
@@ -1,4 +1,4 @@
-FROM launchdarkly/ld-find-code-refs-github-action:2.16.0
+FROM launchdarkly/ld-find-code-refs-github-action:2.17.0
 
 LABEL com.github.actions.name="LaunchDarkly Code References"
 LABEL com.github.actions.description="Find references to feature flags in your code."

--- a/build/metadata/github-actions/README.md
+++ b/build/metadata/github-actions/README.md
@@ -28,7 +28,7 @@ jobs:
       with:
         fetch-depth: 11 # This value must be set if the lookback configuration option is not disabled for find-code-references. Read more: https://github.com/launchdarkly/ld-find-code-refs#searching-for-unused-flags-extinctions
     - name: LaunchDarkly Code References
-      uses: launchdarkly/find-code-references@v2.16.0
+      uses: launchdarkly/find-code-references@v2.17.0
       with:
         accessToken: ${{ secrets.LD_ACCESS_TOKEN }}
         projKey: LD_PROJECT_KEY
@@ -68,7 +68,7 @@ jobs:
       with:
         accessToken: ${{ secrets.LD_ACCESS_TOKEN }}
         projKey: LD_PROJECT_KEY
-        dockerImage: your.registry.example/launchdarkly/ld-find-code-refs-github-action:2.16.0
+        dockerImage: your.registry.example/launchdarkly/ld-find-code-refs-github-action:2.17.0
 ```
 
 Mirror the public image `launchdarkly/ld-find-code-refs-github-action` into your registry (pin `dockerImage` to the scanner image tag you mirrored; it can lag the Action tag). This entry point requires a Docker CLI on the runner (included on GitHub-hosted `ubuntu-*` runners). Existing workflows that use the root Action do not need to change.
@@ -104,7 +104,7 @@ jobs:
       with:
         fetch-depth: 11 # This value must be set if the lookback configuration option is not disabled for find-code-references. Read more: https://github.com/launchdarkly/ld-find-code-refs#searching-for-unused-flags-extinctions
     - name: LaunchDarkly Code References
-      uses: launchdarkly/find-code-references@v2.16.0
+      uses: launchdarkly/find-code-references@v2.17.0
       with:
         accessToken: ${{ secrets.LD_ACCESS_TOKEN }}
         projKey: LD_PROJECT_KEY

--- a/build/metadata/github-actions/docker/action.yml
+++ b/build/metadata/github-actions/docker/action.yml
@@ -52,12 +52,12 @@ inputs:
     description: >-
       Container image to run. Defaults to the public Docker Hub image used by
       the root Action. Set this to your mirrored/proxy image (for example
-      your.registry.example/launchdarkly/ld-find-code-refs-github-action:2.16.0).
+      your.registry.example/launchdarkly/ld-find-code-refs-github-action:2.17.0).
       Authenticate to private registries with docker/login-action (or equivalent)
       in a prior step. Requires a runner with a Docker CLI (GitHub-hosted
       ubuntu-* runners include one).
     required: false
-    default: "launchdarkly/ld-find-code-refs-github-action:2.16.0"
+    default: "launchdarkly/ld-find-code-refs-github-action:2.17.0"
 runs:
   using: composite
   steps:

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "2.16.0"
+const Version = "2.17.0"


### PR DESCRIPTION
## Summary

Prepares the 2.17.0 release by hand, same approach as 2.16.0 in #608 and 2.14.0 in #563: rulesets block the release workflow from pushing version bumps straight to `main`, so the bump lands as a normal PR. Tag, GitHub release, Docker Hub publish (if not already done by a release workflow run), and the downstream `find-code-references` Action update are done manually afterward.

Ships the `/docker` Action entry point from #611 so customers can override the scanner image registry (e.g. Artifactory / Docker Hub proxy).

## What changed

| File | Change |
| --- | --- |
| `internal/version/version.go` | `2.16.0` → `2.17.0` |
| `CHANGELOG.md` | `[Unreleased]` → `2.17.0` (2026-08-13) |
| `build/metadata/github-actions/Dockerfile` | image tag → `2.17.0` |
| `build/metadata/github-actions/README.md` | `find-code-references@v2.17.0` (+ `/docker` example image tag) |
| `build/metadata/github-actions/docker/action.yml` | default `dockerImage` → `…:2.17.0` |

## Behavior notes

- **Bitbucket and CircleCI metadata deliberately untouched.** Those publish targets remain disabled (#593); bumping them would name versions that were never cut.
- **GHA publish is still manual.** After merge: publish Docker images / GitHub release for `v2.17.0` as usual, then `cp -a build/metadata/github-actions/.` into `launchdarkly/find-code-references` (includes new `docker/`), commit, tag `v2.17.0` (and update `v2` if that is still your practice). Use `git add -A` so `docker/action.yml` is included on first publish.

## Test plan

- [x] `go build ./...` (version constant only)
- [x] Diff vs main is only the five files above
- [ ] After merge + Hub image exists: sync `find-code-references` and confirm `docker/action.yml` is present at `v2.17.0`
- [ ] Optional: couscous smoke with published `uses: launchdarkly/find-code-references/docker@v2.17.0`


Made with [Cursor](https://cursor.com)